### PR TITLE
Pulizia residua: dead code nei file recipe/pages

### DIFF
--- a/src/app/components/ds/ConfirmDialog.tsx
+++ b/src/app/components/ds/ConfirmDialog.tsx
@@ -14,7 +14,7 @@ import type { ReactNode } from "react";
 import { CtaButton } from "./CtaButton";
 import { Heading } from "./Heading";
 
-export type ConfirmDialogTone = "primary" | "destructive";
+type ConfirmDialogTone = "primary" | "destructive";
 
 export interface ConfirmDialogAction {
   label: ReactNode;

--- a/src/app/features/recipe/ingredients-section.tsx
+++ b/src/app/features/recipe/ingredients-section.tsx
@@ -27,7 +27,7 @@ import {
   yeastPracticalHint,
 } from "./recipe-output-format";
 
-export interface IngredientsSectionProps {
+interface IngredientsSectionProps {
   recipe: GeneratedRecipe;
   constraints: UserConstraints;
   simple?: boolean;

--- a/src/app/features/recipe/interpretation-narrative-card.tsx
+++ b/src/app/features/recipe/interpretation-narrative-card.tsx
@@ -305,7 +305,7 @@ function InterpretationsModal({
   );
 }
 
-export function InterpretationNarrativeCard({
+function InterpretationNarrativeCard({
   interpretation,
   selected = false,
   onSelect,

--- a/src/app/features/recipe/recipe-match-card.tsx
+++ b/src/app/features/recipe/recipe-match-card.tsx
@@ -5,18 +5,18 @@ import { SCORE_DIMENSIONS, resolveEngineMsgs, type RecipeScores, type ScoreDimen
 import { useCms } from "../cms/cms-context";
 import { createFormatter, t } from "../cms/i18n";
 
-export type RecipeMatchMode = "canonical" | "adapted" | "lab";
+type RecipeMatchMode = "canonical" | "adapted" | "lab";
 
 /** Icona cuore per stato di match — 5 stati distinti (audit role-play giugno 2026). */
-export type MatchIconKey = "handshake" | "heart" | "pulse" | "crack" | "off";
+type MatchIconKey = "handshake" | "heart" | "pulse" | "crack" | "off";
 
 /** Copy CMS per fascia di match (cms.cooking.matchTones). */
-export interface MatchToneCopy {
+interface MatchToneCopy {
   title: string;
   canonical: string;
   adapted: string;
 }
-export interface MatchTonesCopy {
+interface MatchTonesCopy {
   t90: MatchToneCopy;
   t75: MatchToneCopy;
   t60: MatchToneCopy;

--- a/src/app/features/recipe/recipe-setup-panel.tsx
+++ b/src/app/features/recipe/recipe-setup-panel.tsx
@@ -37,28 +37,6 @@ function cmsMessage(cms: CmsContent, key: string, fallback: string): string {
   return cms.engineMessages?.[key] ?? fallback;
 }
 
-/** Miniriepilogo per la minicard Easy: i parametri che la StatStrip non mostra
- *  (sale, forza farina, temperatura di fermentazione, pre-fermento). */
-export function buildAdvancedSummary(
-  recipe: GeneratedRecipe,
-  cms: CmsContent,
-  bcp47: string,
-): string {
-  const nf = new Intl.NumberFormat(bcp47, { maximumFractionDigits: 1 });
-  const saltPct =
-    recipe.flour_g > 0 ? (recipe.salt_g / recipe.flour_g) * 100 : 0;
-  const parts = [
-    `${cms.ui.salt} ${nf.format(saltPct)}%`,
-    `W ${recipe.flour_w}`,
-    `${nf.format(recipe.fermentation_temp_c)} °C`,
-  ];
-  if (recipe.has_pre_ferment && recipe.pre_ferment_type) {
-    const type = recipe.pre_ferment_type;
-    parts.push(type.charAt(0).toUpperCase() + type.slice(1));
-  }
-  return parts.join(" · ");
-}
-
 function localizedVersionLabel(cms: CmsContent, label: string): string {
   return cmsMessage(cms, `version.label.${label}`, label);
 }

--- a/src/app/features/recipe/recipe-view.tsx
+++ b/src/app/features/recipe/recipe-view.tsx
@@ -18,7 +18,7 @@ import { Heading, IconButton } from "../../components/ds/index";
 import { ImageWithFallback } from "../../components/media/ImageWithFallback";
 import { RecipeOutput } from "./recipe-output";
 import { RecipeSectionTabs, type RecipePrimaryTab } from "./recipe-section-tabs";
-import { TOPPING_LIBRARY, getToppingForStyle, getRecipesByAuthenticity, TOPPING_CONCEPTS } from "../../data/topping-library";
+import { getToppingForStyle, getRecipesByAuthenticity, TOPPING_CONCEPTS } from "../../data/topping-library";
 import { useIsMobile } from "../../hooks/use-mobile";
 import { FireGlow } from "../cooking/fire-glow";
 import { useCms, type CmsContent } from "../cms/cms-context";

--- a/src/app/features/recipe/recommended-styles.tsx
+++ b/src/app/features/recipe/recommended-styles.tsx
@@ -60,7 +60,7 @@ const FALLBACK =
 /* VPL-C3: dimensione del match da una reason key (rec.*). Serve a scegliere
  * l'icona sintetica sulla tile e a raggruppare/visualizzare i reasons nel
  * dettaglio. Esportata per riuso in style-detail-sheet. */
-export type MatchDimension = "time" | "oven" | "skill" | "equipment" | "pantry";
+type MatchDimension = "time" | "oven" | "skill" | "equipment" | "pantry";
 export function reasonDimension(key: string): MatchDimension {
   if (key.includes("time")) return "time";
   if (key.includes("oven") || key.includes("Wood") || key.includes("refractory"))

--- a/src/app/pages/home.tsx
+++ b/src/app/pages/home.tsx
@@ -440,7 +440,6 @@ export function HomePage() {
     useStylesOverride();
   const {
     cms,
-    bcp47,
     modifiedCount,
     resetAll: cmsResetAll,
   } = useCms();

--- a/src/app/pages/recipe.tsx
+++ b/src/app/pages/recipe.tsx
@@ -43,7 +43,6 @@ type GeneratedRecipe,
 type OvenType,
 type PanConfig,
 type PizzaStyle,
-type RecipeScores,
 type SkillLevel,
 type UserConstraints
 } from "../domain/pizza-engine";
@@ -70,7 +69,7 @@ getVersions,
 type StyleVersion,
 } from "../data/style-versions";
 import { useStylesOverride } from "../context/styles-override-context";
-import { TOPPING_CONCEPTS, resolveTopping, TOPPING_LIBRARY } from "../data/topping-library";
+import { resolveTopping, TOPPING_LIBRARY } from "../data/topping-library";
 import {
   findSavedRecipe,
   removeRecipe,
@@ -199,7 +198,7 @@ function replaceRecipeSearchParams(
 /* ═══ RECIPE PAGE ═══ */
 export function RecipePage() {
   const { styleId } = useParams<{ styleId: string }>();
-  const { cms, bcp47 } = useCms();
+  const { cms } = useCms();
   const { effectiveStyles } = useStylesOverride();
 
   const db = effectiveStyles ?? STYLES_DB;
@@ -220,7 +219,6 @@ function RecipeContent({
   style: PizzaStyle;
   cms: any;
 }) {
-  const { bcp47 } = useCms();
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();


### PR DESCRIPTION
Follow-up del #26: pulizia dei file che allora erano in lavorazione (redesign tab ricetta) e che avevo escluso di proposito.

- Eliminata `buildAdvancedSummary` (mai chiamata) da `recipe-setup-panel.tsx`
- Rimossi i binding `bcp47` inutilizzati in `home.tsx` e `recipe.tsx` (2 punti) e gli import morti `RecipeScores`, `TOPPING_CONCEPTS` (recipe.tsx), `TOPPING_LIBRARY` (recipe-view.tsx)
- De-esportati 8 simboli usati solo internamente: `MatchIconKey`/`MatchToneCopy`/`MatchTonesCopy`/`RecipeMatchMode` (recipe-match-card), `InterpretationNarrativeCard`, `IngredientsSectionProps`, `MatchDimension`, `ConfirmDialogTone`

Con questo `tsc --noEmit --noUnusedLocals` è pulito sull'intero codebase.

Verifica: `npm run verify` ok (tsc + check:tokens 0 violazioni + 22/22 test Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)