### PR TITLE
refactor(ds): allineamento bidirezionale al design system

### DIFF
--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -100,6 +100,32 @@ const RULES = [
     },
   },
   {
+    id: "tw-raw-palette",
+    desc: "Classe palette Tailwind di default (bg-red-500…) → token semantico. La palette è disattivata in @theme: la classe NON compila e fallisce in silenzio.",
+    test: (l) =>
+      l.match(
+        /\b(?:bg|text|border|ring|fill|stroke|from|to|via|shadow|outline|decoration|accent|caret|divide)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\d+(?:\/\d+)?\b/g,
+      ),
+  },
+  {
+    id: "arbitrary-font-size",
+    desc: "Font-size arbitrario text-[Npx] → scala tipografica (text-2xs, text-xs, …) o composite type-*.",
+    excludeFiles: SIZING_TOOLING_EXEMPT,
+    test: (l) => l.match(/\btext-\[\d+(?:\.\d+)?px\]/g),
+  },
+  {
+    id: "arbitrary-z",
+    desc: "Z-index arbitrario z-[N] → scala nativa (z-10…z-50) o token AF: z-(--z-widget|--z-modal|--z-skiplink).",
+    excludeFiles: SIZING_TOOLING_EXEMPT,
+    test: (l) => l.match(/\bz-\[\d+\]/g),
+  },
+  {
+    id: "arbitrary-scale",
+    desc: "Scale arbitrario scale-[x] → valore bare Tailwind 4 (scale-98, active:scale-95, …).",
+    excludeFiles: SIZING_TOOLING_EXEMPT,
+    test: (l) => l.match(/\bscale-\[[\d.]+\]/g),
+  },
+  {
     id: "hardcoded-text",
     desc: "Testo user-facing hardcoded in aria-label/placeholder/title/alt → spostalo nel CMS (cms.*).",
     excludeDs: true,
@@ -181,10 +207,111 @@ try {
   /* theme.css assente: ignora */
 }
 
+/* ── Allineamento bidirezionale: token/composite DEFINITI ma mai CONSUMATI ──
+ * Il tier system vale nei due sensi: il codice consuma solo token, e il
+ * design system non accumula token morti. Un token è "vivo" se compare come
+ * var(--x) (in app o in theme.css stesso), come stringa letterale nel codice,
+ * o — per i token @theme — come utility Tailwind derivata (bg-primary…).
+ * Token in fase di rollout: aggiungerli a STAGED_TOKENS con una scadenza. */
+const STAGED_TOKENS = new Set([
+  /* es. "--nuovo-token", // in rollout fino a <data/PR> */
+]);
+
+function walkAll(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walkAll(full, acc);
+    else if (/\.(ts|tsx|css|html)$/.test(entry.name)) acc.push(full);
+  }
+  return acc;
+}
+
+try {
+  const css = readFileSync(CSS_FILE, "utf8");
+  const cssLines = css.split("\n");
+  const lineOf = (name, matcher) => {
+    const idx = cssLines.findIndex((l) => matcher.test(l));
+    return idx === -1 ? 1 : idx + 1;
+  };
+  const themeBlock = css.match(/@theme inline \{[\s\S]*?\n\}/)?.[0] ?? "";
+  const themeTokens = new Set(
+    [...themeBlock.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm)].map((m) => m[1]),
+  );
+  const allSources = [...walkAll("src"), "index.html"]
+    .filter((f) => !f.replace(/\\/g, "/").endsWith("theme.css"))
+    .map((f) => {
+      try {
+        return readFileSync(f, "utf8");
+      } catch {
+        return "";
+      }
+    })
+    .join("\n");
+
+  const tokenDefs = [
+    ...new Set([...css.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm)].map((m) => m[1])),
+  ];
+  for (const t of tokenDefs) {
+    if (STAGED_TOKENS.has(t)) continue;
+    const name = t.slice(2);
+    const varRe = new RegExp(`var\\(${t}[\\),]`);
+    if (varRe.test(allSources) || varRe.test(css)) continue;
+    if (allSources.includes(t)) continue; // riferimento letterale (stringa JS)
+    if (themeTokens.has(t)) {
+      /* Token @theme: vivo anche se consumato via utility Tailwind derivata.
+       * `--text-2xs--line-height` è un modificatore del token base: segue
+       * la sorte di `--text-2xs`, non va contato da solo. */
+      if (name.includes("--")) continue;
+      let utilRe = null;
+      if (name.startsWith("color-")) {
+        utilRe = new RegExp(
+          `\\b(?:bg|text|border|ring|fill|stroke|divide|outline|accent|caret|decoration|from|to|via|shadow|placeholder|inset-ring)-${name.slice(6)}(?![a-z-])`,
+        );
+      } else if (name.startsWith("radius-")) {
+        utilRe = new RegExp(`\\brounded(?:-[trbleyxs]{1,2})?-${name.slice(7)}(?![a-z-])`);
+      } else if (name.startsWith("font-")) {
+        utilRe = new RegExp(`\\bfont-${name.slice(5)}(?![a-z-])`);
+      } else if (name.startsWith("text-")) {
+        utilRe = new RegExp(`\\btext-${name.slice(5)}(?![a-z-])`);
+      }
+      if (utilRe && utilRe.test(allSources)) continue;
+    }
+    violations.push({
+      file: CSS_FILE,
+      line: lineOf(t, new RegExp(`^\\s*${t}\\s*:`)),
+      rule: "dead-token",
+      severity: "error",
+      hits: [t],
+    });
+  }
+
+  const compBlock = css
+    .slice(css.indexOf("@layer components"))
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+  const compClasses = [
+    ...new Set([...compBlock.matchAll(/^\s*\.([a-z][a-z0-9-]+)/gm)].map((m) => m[1])),
+  ];
+  for (const c of compClasses) {
+    if (!allSources.includes(c)) {
+      violations.push({
+        file: CSS_FILE,
+        line: lineOf(c, new RegExp(`^\\s*\\.${c}\\b`)),
+        rule: "dead-composite",
+        severity: "error",
+        hits: [`.${c}`],
+      });
+    }
+  }
+} catch {
+  /* theme.css assente: ignora */
+}
+
 const errors = violations.filter((v) => v.severity !== "warn");
 const warnings = violations.filter((v) => v.severity === "warn");
 const EXTRA_DESC = {
   "css-font-literal": "theme.css: famiglia font letterale → usare var(--font-sans|-serif|-mono)",
+  "dead-token": "theme.css: token definito ma mai consumato (né var(), né utility @theme) → rimuoverlo o metterlo in STAGED_TOKENS",
+  "dead-composite": "theme.css: classe composite @layer components mai usata → rimuoverla",
 };
 
 function report(list, stream) {

--- a/src/app/components/design-system/carousel-variants.tsx
+++ b/src/app/components/design-system/carousel-variants.tsx
@@ -66,7 +66,7 @@ function Arrow({ dir, onClick }: { dir: "left" | "right"; onClick: () => void })
       onClick={onClick}
       whileHover={{ scale: 1.08 }}
       transition={SP.arrow}
-      className="w-9 h-9 rounded-full flex items-center justify-center active:scale-[0.82] transition-transform"
+      className="w-9 h-9 rounded-full flex items-center justify-center active:scale-82 transition-transform"
       style={{
         background: "color-mix(in srgb, var(--container-page) 88%, transparent)",
         backdropFilter: "blur(12px) saturate(1.4)",
@@ -90,7 +90,7 @@ function Dots({ count, active, onSelect, id }: { count: number; active: number; 
           <motion.button
             key={i}
             onClick={() => onSelect(i)}
-            className="relative rounded-full overflow-hidden active:scale-[0.8] transition-transform"
+            className="relative rounded-full overflow-hidden active:scale-80 transition-transform"
             style={{ border: "none", cursor: "pointer", outline: "none", padding: 0, background: "transparent" }}
             animate={{ width: isActive ? 24 : 8, height: 8 }}
             transition={SP.dot}

--- a/src/app/components/design-system/components-a.tsx
+++ b/src/app/components/design-system/components-a.tsx
@@ -300,7 +300,7 @@ function CardsSpec() {
           {CARD_V.map(c => (
             <div key={c.v} className="flex flex-col gap-2">
               <span className="type-label" style={{ color: c.c }}>{c.v}</span>
-              <Surface variant="card" className="p-4 rounded-2xl cursor-pointer active:scale-[0.98] transition-all hover:-translate-y-0.5 hover:shadow-md" style={{ background: c.bg, border: "1px solid var(--outline-variant)", boxShadow: c.s || "none" }}>
+              <Surface variant="card" className="p-4 rounded-2xl cursor-pointer active:scale-98 transition-all hover:-translate-y-0.5 hover:shadow-md" style={{ background: c.bg, border: "1px solid var(--outline-variant)", boxShadow: c.s || "none" }}>
                 <p style={{ fontFamily: "'DM Sans',sans-serif", fontSize: "var(--font-size-lg)", color: "var(--text-default)", lineHeight: "var(--leading-relaxed)" }}>{c.d}</p>
               </Surface>
             </div>
@@ -314,7 +314,7 @@ function CardsSpec() {
             { t: "Napoletana STG", s: "AVPN", b: "Forno legna 450\u00b0C, 60-90s.", img: "https://images.unsplash.com/photo-1604068549290-dea0e4a305ca?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxuZWFwb2xpdGFuJTIwcGl6emElMjBtYXJnaGVyaXRhJTIwd29vZCUyMGZpcmV8ZW58MXx8fHwxNzcxMjMwNTM5fDA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=vulcan&utm_medium=referral", badge: "W 250\u2013320", bc: "var(--primary)" },
             { t: "Lunga Maturazione", s: "72h frigo", b: "Fermentazione 4\u00b0C, alveolatura aperta.", img: "https://images.unsplash.com/photo-1738717201744-9faf699eea3d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwaXp6YSUyMGRvdWdoJTIwZmVybWVudGF0aW9uJTIwc291cmRvdWdofGVufDF8fHx8MTc3MTIzMDU0Mnww&ixlib=rb-4.1.0&q=80&w=1080&utm_source=vulcan&utm_medium=referral", badge: "72h frigo", bc: "var(--cta)" },
           ].map(c => (
-            <motion.div key={c.t} className="rounded-2xl overflow-hidden cursor-pointer active:scale-[0.98]" style={{ background: "var(--surface-container-low)", border: "1px solid var(--outline-variant)" }} whileHover={{ y: -4, boxShadow: "var(--shadow-lg)" }} transition={{ type: "spring", stiffness: 400, damping: 25 }}>
+            <motion.div key={c.t} className="rounded-2xl overflow-hidden cursor-pointer active:scale-98" style={{ background: "var(--surface-container-low)", border: "1px solid var(--outline-variant)" }} whileHover={{ y: -4, boxShadow: "var(--shadow-lg)" }} transition={{ type: "spring", stiffness: 400, damping: 25 }}>
               <div className="relative" style={{ aspectRatio: "16/9", overflow: "hidden" }}>
                 <ImageWithFallback src={c.img} alt={c.t} className="w-full h-full" style={{ objectFit: "cover", display: "block" }} />
                 <div className="absolute top-3 left-3">

--- a/src/app/components/design-system/components-b.tsx
+++ b/src/app/components/design-system/components-b.tsx
@@ -201,7 +201,7 @@ function StatStripSpec() {
             return (
               <motion.div
                 key={stat.label}
-                className="flex-1 flex flex-col items-center gap-1.5 py-3 rounded-xl cursor-pointer active:scale-[0.96]"
+                className="flex-1 flex flex-col items-center gap-1.5 py-3 rounded-xl cursor-pointer active:scale-96"
                 style={{ background: "var(--surface-container)" }}
                 whileHover={{ y: -3, boxShadow: "var(--shadow-md)" }}
                 transition={{ type: "spring", stiffness: 400, damping: 25 }}
@@ -321,7 +321,7 @@ function SingleToast({
       {toast.action && (
         <button className="active:scale-95 transition-transform" style={{ fontFamily: "'DM Sans', sans-serif", fontSize: "var(--font-size-base)", fontWeight: "var(--weight-semibold)" as any, color: cfg.color, background: "none", border: "none", cursor: "pointer", outline: "none", whiteSpace: "nowrap", textTransform: "uppercase", letterSpacing: "var(--tracking-label)" }}>{toast.action}</button>
       )}
-      <button onClick={onDismiss} className="active:scale-[0.85] transition-transform" style={{ color: "var(--muted-foreground)", opacity: 0.5, cursor: "pointer", background: "none", border: "none", outline: "none", flexShrink: 0, padding: "2px" }} aria-label="Chiudi toast">
+      <button onClick={onDismiss} className="active:scale-85 transition-transform" style={{ color: "var(--muted-foreground)", opacity: 0.5, cursor: "pointer", background: "none", border: "none", outline: "none", flexShrink: 0, padding: "2px" }} aria-label="Chiudi toast">
         <X size={14} />
       </button>
     </motion.div>

--- a/src/app/components/design-system/components-c.tsx
+++ b/src/app/components/design-system/components-c.tsx
@@ -121,7 +121,7 @@ function NavigationBarSpec() {
                 const isActive = activeNavMobile === item.id;
                 const Icon = item.icon;
                 return (
-                  <motion.button key={item.id} onClick={() => setActiveNavMobile(item.id)} className="flex flex-col items-center gap-0.5 relative active:scale-[0.9] transition-transform" style={{ background: "rgba(0,0,0,0)", border: "none", cursor: "pointer", outline: "none", padding: "4px 12px" }}>
+                  <motion.button key={item.id} onClick={() => setActiveNavMobile(item.id)} className="flex flex-col items-center gap-0.5 relative active:scale-90 transition-transform" style={{ background: "rgba(0,0,0,0)", border: "none", cursor: "pointer", outline: "none", padding: "4px 12px" }}>
                     <div className="relative">
                       {isActive && <motion.div layoutId="mobileNavPill" className="absolute rounded-full" style={{ inset: "-4px -12px", background: "color-mix(in srgb, var(--primary) 12%, transparent)" }} transition={{ type: "spring", stiffness: 500, damping: 30 }} />}
                       <Icon size={18} style={{ color: isActive ? "var(--primary)" : "var(--muted-foreground)", position: "relative", zIndex: 1 }} />
@@ -505,7 +505,7 @@ function ModalScoreDashboardSpec() {
                 <motion.button onClick={() => setNerdMode(!nerdMode)} className="flex items-center gap-2 px-3 py-1.5 rounded-lg active:scale-95 transition-transform" style={{ background: nerdMode ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "var(--surface-container)", border: nerdMode ? "1px solid var(--primary)" : "1px solid var(--outline-variant)", fontFamily: "'DM Sans', sans-serif", fontSize: "var(--font-size-lg)", fontWeight: "var(--weight-semibold)" as any, color: nerdMode ? "var(--primary)" : "var(--muted-foreground)", cursor: "pointer", outline: "none", letterSpacing: "var(--tracking-label)", textTransform: "uppercase" }}>
                   <FlaskConical size={12} />PizzaNerd
                 </motion.button>
-                <motion.button onClick={() => setModalOpen(false)} className="w-8 h-8 rounded-lg flex items-center justify-center active:scale-[0.85] transition-transform" style={{ background: "var(--surface-container)", color: "var(--muted-foreground)", border: "1px solid var(--outline-variant)", cursor: "pointer", outline: "none" }} aria-label="Chiudi modale">
+                <motion.button onClick={() => setModalOpen(false)} className="w-8 h-8 rounded-lg flex items-center justify-center active:scale-85 transition-transform" style={{ background: "var(--surface-container)", color: "var(--muted-foreground)", border: "1px solid var(--outline-variant)", cursor: "pointer", outline: "none" }} aria-label="Chiudi modale">
                   <X size={16} />
                 </motion.button>
               </div>

--- a/src/app/components/design-system/components-f.tsx
+++ b/src/app/components/design-system/components-f.tsx
@@ -625,7 +625,7 @@ function TabsSpec() {
                   key={tab.id}
                   ref={(el) => { tabRefs.current[tab.id] = el; }}
                   onClick={() => setActiveTab(tab.id)}
-                  className="flex-1 flex flex-col items-center gap-1 py-3 px-2 relative active:scale-[0.97]"
+                  className="flex-1 flex flex-col items-center gap-1 py-3 px-2 relative active:scale-97"
                   style={{
                     background: "rgba(0,0,0,0)",
                     border: "none",
@@ -688,7 +688,7 @@ function TabsSpec() {
               <button
                 key={tab.id}
                 onClick={() => setActiveSecondary(tab.id)}
-                className="flex-1 py-2.5 px-3 relative active:scale-[0.97]"
+                className="flex-1 py-2.5 px-3 relative active:scale-97"
                 style={{
                   background: "rgba(0,0,0,0)",
                   border: "none",

--- a/src/app/components/design-system/components-g2.tsx
+++ b/src/app/components/design-system/components-g2.tsx
@@ -80,7 +80,7 @@ function TooltipSpec() {
                 onMouseLeave={() => setHoveredPlain(null)}
               >
                 <motion.button
-                  className="w-10 h-10 rounded-xl flex items-center justify-center cursor-pointer active:scale-[0.9] transition-transform"
+                  className="w-10 h-10 rounded-xl flex items-center justify-center cursor-pointer active:scale-90 transition-transform"
                   style={{
                     background: "var(--surface-container)",
                     border: "none",
@@ -134,7 +134,7 @@ function TooltipSpec() {
               <div key={item.id} className="relative">
                 <button
                   onClick={() => setOpenRich(isOpen ? null : item.id)}
-                  className="w-10 h-10 rounded-xl flex items-center justify-center cursor-pointer active:scale-[0.9] transition-transform"
+                  className="w-10 h-10 rounded-xl flex items-center justify-center cursor-pointer active:scale-90 transition-transform"
                   style={{
                     background: isOpen ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "var(--surface-container)",
                     border: "none",
@@ -341,7 +341,7 @@ function DialogSpec() {
               <div className="flex items-center gap-3">
                 <motion.button
                   onClick={() => setFullOpen(false)}
-                  className="w-10 h-10 rounded-full flex items-center justify-center active:scale-[0.9] transition-transform"
+                  className="w-10 h-10 rounded-full flex items-center justify-center active:scale-90 transition-transform"
                   style={{ background: "rgba(0,0,0,0)", border: "none", cursor: "pointer", outline: "none", color: "var(--text-default)" }}
                   aria-label="Chiudi"
                 >
@@ -512,7 +512,7 @@ function IconButtonSpec() {
                   <motion.button
                     key={i}
                     whileHover={{ scale: 1.05 }}
-                    className="w-10 h-10 rounded-full flex items-center justify-center active:scale-[0.85] transition-transform"
+                    className="w-10 h-10 rounded-full flex items-center justify-center active:scale-85 transition-transform"
                     style={{
                       background: v.bg,
                       color: v.fg,
@@ -545,7 +545,7 @@ function IconButtonSpec() {
               <div key={item.id} className="flex flex-col items-center gap-2">
                 <button
                   onClick={() => toggleIcon(item.id)}
-                  className="w-12 h-12 rounded-full flex items-center justify-center active:scale-[0.8]"
+                  className="w-12 h-12 rounded-full flex items-center justify-center active:scale-80"
                   style={{
                     background: isOn ? "var(--primary)" : "rgba(0,0,0,0)",
                     color: isOn ? "var(--primary-foreground)" : "var(--on-surface-variant)",
@@ -587,7 +587,7 @@ function IconButtonSpec() {
           ].map((s) => (
             <div key={s.label} className="flex flex-col items-center gap-2">
               <motion.div
-                className="rounded-full flex items-center justify-center cursor-pointer active:scale-[0.85] transition-transform"
+                className="rounded-full flex items-center justify-center cursor-pointer active:scale-85 transition-transform"
                 style={{
                   width: s.size,
                   height: s.size,

--- a/src/app/components/design-system/components-h.tsx
+++ b/src/app/components/design-system/components-h.tsx
@@ -472,7 +472,7 @@ function SpringArrow({ direction, onClick, disabled }: { direction: "left" | "ri
       disabled={disabled}
       whileHover={{ scale: 1.08 }}
       transition={SP.arrow}
-      className="w-9 h-9 rounded-full flex items-center justify-center active:scale-[0.82] transition-transform"
+      className="w-9 h-9 rounded-full flex items-center justify-center active:scale-82 transition-transform"
       style={{
         background: "color-mix(in srgb, var(--container-page) 88%, transparent)",
         backdropFilter: "blur(12px) saturate(1.4)",
@@ -698,7 +698,7 @@ function CarouselSpec() {
               <motion.button
                 key={item.id}
                 onClick={() => { setDir(i > focus ? 1 : -1); setFocus(i); }}
-                className="relative rounded-full overflow-hidden active:scale-[0.8] transition-transform"
+                className="relative rounded-full overflow-hidden active:scale-80 transition-transform"
                 style={{ border: "none", cursor: "pointer", outline: "none", padding: 0, background: "rgba(0,0,0,0)" }}
                 animate={{ width: isActive ? 24 : 8, height: 8 }}
                 transition={SP.dot}

--- a/src/app/components/design-system/foundations-dynamics.tsx
+++ b/src/app/components/design-system/foundations-dynamics.tsx
@@ -61,7 +61,7 @@ function ElevationSection() {
         {SHADOWS.map((s) => (
           <motion.div
             key={s.name}
-            className="p-5 rounded-2xl cursor-pointer active:scale-[0.98] transition-transform"
+            className="p-5 rounded-2xl cursor-pointer active:scale-98 transition-transform"
             style={{ background: "var(--surface-container-low)", boxShadow: s.value === "none" ? "none" : s.value, border: "1px solid var(--outline-variant)" }}
             whileHover={{ y: -2, scale: 1.01 }}
             transition={{ type: "spring", stiffness: 400, damping: 25 }}
@@ -307,7 +307,7 @@ function IconographySection() {
               {set.icons.map((Icon, i) => (
                 <motion.div
                   key={i}
-                  className="w-10 h-10 rounded-xl flex items-center justify-center cursor-pointer active:scale-[0.9] transition-transform"
+                  className="w-10 h-10 rounded-xl flex items-center justify-center cursor-pointer active:scale-90 transition-transform"
                   style={{ background: "var(--surface-container)" }}
                   whileHover={{ scale: 1.15 }}
                   transition={{ type: "spring", stiffness: 500, damping: 25 }}

--- a/src/app/components/design-system/foundations-ext.tsx
+++ b/src/app/components/design-system/foundations-ext.tsx
@@ -560,7 +560,7 @@ function ImageTreatmentSection() {
             {STYLE_PHOTOS.map((photo) => (
               <motion.div
                 key={photo.label}
-                className="flex flex-col gap-2 cursor-pointer active:scale-[0.97] transition-transform"
+                className="flex flex-col gap-2 cursor-pointer active:scale-97 transition-transform"
                 whileHover={{ y: -4, boxShadow: "var(--shadow-md)" }}
                 transition={{ type: "spring", stiffness: 400, damping: 25 }}
               >

--- a/src/app/components/design-system/foundations-glass.tsx
+++ b/src/app/components/design-system/foundations-glass.tsx
@@ -66,7 +66,7 @@ function GlassSpecimen({
     <motion.div
       whileHover={{ scale: 1.03 }}
       transition={{ type: "spring", stiffness: 400, damping: 25 }}
-      className="relative flex flex-col items-center justify-center cursor-pointer overflow-hidden active:scale-[0.97] transition-transform"
+      className="relative flex flex-col items-center justify-center cursor-pointer overflow-hidden active:scale-97 transition-transform"
       style={{
         width: "120px",
         height: "120px",
@@ -423,7 +423,7 @@ function GlassmorphismLiquidGlassSection() {
             return (
               <motion.div
                 key={p.context}
-                className="surface-card p-4 active:scale-[0.98] transition-transform"
+                className="surface-card p-4 active:scale-98 transition-transform"
                 whileHover={{ y: -2, boxShadow: "var(--shadow-md)" }}
                 transition={{ type: "spring", stiffness: 400, damping: 25 }}
               >

--- a/src/app/components/design-system/foundations-m3e.tsx
+++ b/src/app/components/design-system/foundations-m3e.tsx
@@ -334,7 +334,7 @@ function ContainerTransformSection() {
                     damping: 28,
                     mass: 1,
                   }}
-                  className="flex items-center justify-center overflow-hidden cursor-pointer active:scale-[0.97] transition-transform"
+                  className="flex items-center justify-center overflow-hidden cursor-pointer active:scale-97 transition-transform"
                   style={{
                     border: "none",
                     outline: "none",

--- a/src/app/components/design-system/index.tsx
+++ b/src/app/components/design-system/index.tsx
@@ -455,7 +455,7 @@ export function DesignSystemTab({
                 <motion.button
                   key={s.id}
                   onClick={() => scrollToSection(s.id)}
-                  className="flex items-center gap-2 px-2 py-1.5 rounded-md active:scale-[0.97] transition-transform"
+                  className="flex items-center gap-2 px-2 py-1.5 rounded-md active:scale-97 transition-transform"
                   style={{
                     fontFamily: "'DM Sans', sans-serif",
                     fontSize: "var(--font-size-lg)",
@@ -523,7 +523,7 @@ export function DesignSystemTab({
                 <motion.button
                   key={s.id}
                   onClick={() => scrollToSection(s.id)}
-                  className="flex items-center gap-2 px-2 py-1.5 rounded-md active:scale-[0.97] transition-transform"
+                  className="flex items-center gap-2 px-2 py-1.5 rounded-md active:scale-97 transition-transform"
                   style={{
                     fontFamily: "'DM Sans', sans-serif",
                     fontSize: "var(--font-size-lg)",
@@ -591,7 +591,7 @@ export function DesignSystemTab({
                 <motion.button
                   key={s.id}
                   onClick={() => scrollToSection(s.id)}
-                  className="flex items-center gap-2 px-2 py-1.5 rounded-md active:scale-[0.97] transition-transform"
+                  className="flex items-center gap-2 px-2 py-1.5 rounded-md active:scale-97 transition-transform"
                   style={{
                     fontFamily: "'DM Sans', sans-serif",
                     fontSize: "var(--font-size-lg)",
@@ -829,7 +829,7 @@ export function DesignSystemTab({
                 >
                   <motion.button
                     onClick={() => toggleSection(section.id)}
-                    className="w-full flex items-center justify-between py-3 px-1 active:scale-[0.98] transition-transform"
+                    className="w-full flex items-center justify-between py-3 px-1 active:scale-98 transition-transform"
                     style={{
                       borderBottom: "1px solid var(--outline-variant)",
                     }}

--- a/src/app/components/design-system/patterns-templates.tsx
+++ b/src/app/components/design-system/patterns-templates.tsx
@@ -180,7 +180,7 @@ function SelectionPatternSpec() {
                       <motion.button
                         key={card.id}
                         onClick={() => setSelectedCard(card.id)}
-                        className="relative p-4 rounded-2xl text-left cursor-pointer active:scale-[0.97]"
+                        className="relative p-4 rounded-2xl text-left cursor-pointer active:scale-97"
                         style={{
                           background: isActive
                             ? tc.bg
@@ -275,7 +275,7 @@ function SelectionPatternSpec() {
                 principi={[
                   "Un solo elemento attivo per gruppo (single-select). Il check animato conferma la scelta.",
                   "Il colore di selezione riflette il contesto: primary per chip generici, tier-color per card stilistiche.",
-                  "Feedback tattile immediato: active:scale-95 (chip) o active:scale-[0.97] (card).",
+                  "Feedback tattile immediato: active:scale-95 (chip) o active:scale-97 (card).",
                   "L'icona si swap-anima (icon → check) con spring transition, mai cross-fade.",
                 ]}
                 quandoUsare="Ogni volta che l'utente deve scegliere tra opzioni discrete. Chip per 2-6 opzioni testuali, Card per opzioni con contenuto rich (immagine, score, metadata)."
@@ -710,7 +710,7 @@ function ProgressiveDisclosureSpec() {
                 >
                   <button
                     onClick={() => setAccordionOpen(!accordionOpen)}
-                    className="w-full flex items-center justify-between px-5 py-3.5 text-left active:scale-[0.99] transition-transform cursor-pointer"
+                    className="w-full flex items-center justify-between px-5 py-3.5 text-left active:scale-99 transition-transform cursor-pointer"
                     aria-expanded={accordionOpen}
                   >
                     <div className="flex items-center gap-2.5">
@@ -984,7 +984,7 @@ function FloatingCTASpec() {
                             stiffness: 400,
                             damping: 25,
                           }}
-                          className="flex items-center gap-2 h-11 px-7 rounded-full active:scale-[0.97]"
+                          className="flex items-center gap-2 h-11 px-7 rounded-full active:scale-97"
                           style={{
                             pointerEvents: "auto",
                             background: "var(--cta-btn-bg)",
@@ -1011,7 +1011,7 @@ function FloatingCTASpec() {
                             stiffness: 400,
                             damping: 25,
                           }}
-                          className="flex items-center gap-2 h-11 px-7 rounded-full active:scale-[0.97]"
+                          className="flex items-center gap-2 h-11 px-7 rounded-full active:scale-97"
                           style={{
                             pointerEvents: "auto",
                             background: "var(--cta-btn-bg)",
@@ -1037,7 +1037,7 @@ function FloatingCTASpec() {
                           style={{ pointerEvents: "auto" }}
                         >
                           <button
-                            className="flex items-center gap-2 h-11 px-5 rounded-full active:scale-[0.97]"
+                            className="flex items-center gap-2 h-11 px-5 rounded-full active:scale-97"
                             style={{
                               background: "var(--surface-container)",
                               color: "var(--text-default)",
@@ -1052,7 +1052,7 @@ function FloatingCTASpec() {
                             Cambia stile
                           </button>
                           <button
-                            className="flex items-center gap-2 h-11 px-5 rounded-full active:scale-[0.97]"
+                            className="flex items-center gap-2 h-11 px-5 rounded-full active:scale-97"
                             style={{
                               background: "rgba(0,0,0,0)",
                               color: "var(--muted-foreground)",

--- a/src/app/components/ds/Checkbox.tsx
+++ b/src/app/components/ds/Checkbox.tsx
@@ -78,7 +78,7 @@ export function Checkbox({
       disabled={disabled}
       onClick={() => onCheckedChange?.(!isChecked)}
       className={[
-        "flex items-start gap-3 py-3 px-2 rounded-xl text-left active:scale-[0.98] transition-transform",
+        "flex items-start gap-3 py-3 px-2 rounded-xl text-left active:scale-98 transition-transform",
         label || description ? "w-full" : "",
         className,
       ]

--- a/src/app/components/ds/ConfirmDialog.tsx
+++ b/src/app/components/ds/ConfirmDialog.tsx
@@ -43,7 +43,7 @@ export interface ConfirmDialogProps {
 }
 
 const ACTION_BASE =
-  "w-full h-12 rounded-full active:scale-[0.98] transition-transform flex items-center justify-center gap-2";
+  "w-full h-12 rounded-full active:scale-98 transition-transform flex items-center justify-center gap-2";
 
 export function ConfirmDialog({
   open,
@@ -127,7 +127,7 @@ export function ConfirmDialog({
                     <CtaButton
                       key={i}
                       onClick={action.onClick}
-                      className="w-full h-12 active:scale-[0.98]"
+                      className="w-full h-12 active:scale-98"
                       style={{ fontSize: "var(--font-size-lg)" }}
                     >
                       {action.label}

--- a/src/app/components/ds/ModalSheet.tsx
+++ b/src/app/components/ds/ModalSheet.tsx
@@ -1,0 +1,157 @@
+/**
+ * ds/ModalSheet — T4 modale responsive token-driven, context-free.
+ *
+ * Guscio unico per i modali dell'app: sheet dal bordo inferiore su mobile,
+ * card centrata da `sm` in su. Scrim, superficie, animazione e layering
+ * consumano SOLO token (`--z-modal`, `--backdrop-glass-*`, `--sheet-glass-bg`,
+ * `--dialog-*`, `--container-*`). Chiude su click-scrim e su Escape.
+ *
+ * Varianti ortogonali:
+ *  - `scrim`    glass (blur forte) · soft (blur leggero) · plain (solo tinta)
+ *  - `surface`  glass · glass-dense (picker) · solid
+ *  - `entry`    slide (sheet dal basso) · pop (fade+scale centrato)
+ *  - `size`     sm 440px · md 640px · lg 672px · xl 1160px
+ *  - `height`   auto (cap max-h) · full (workspace ~92dvh)
+ */
+import { AnimatePresence, motion } from "motion/react";
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+
+export interface ModalSheetProps {
+  open: boolean;
+  onClose: () => void;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+  size?: "sm" | "md" | "lg" | "xl";
+  scrim?: "glass" | "soft" | "plain";
+  surface?: "glass" | "glass-dense" | "solid";
+  entry?: "slide" | "pop";
+  height?: "auto" | "full";
+  /** Classi extra sul pannello: padding/overflow del contenuto. */
+  panelClassName?: string;
+  children: ReactNode;
+}
+
+const SIZE_CLASS: Record<NonNullable<ModalSheetProps["size"]>, string> = {
+  sm: "sm:max-w-[440px]",
+  md: "sm:max-w-[640px]",
+  lg: "sm:max-w-2xl",
+  xl: "sm:max-w-[1160px]",
+};
+
+const HEIGHT_CLASS: Record<NonNullable<ModalSheetProps["height"]>, string> = {
+  auto: "max-h-[85dvh] sm:max-h-[80vh]",
+  full: "h-[92dvh] max-h-[92dvh] sm:h-[min(760px,88vh)] sm:max-h-[88vh]",
+};
+
+const SCRIM_STYLE: Record<
+  NonNullable<ModalSheetProps["scrim"]>,
+  React.CSSProperties
+> = {
+  glass: {
+    background: "var(--dialog-scrim-strong)",
+    backdropFilter: "var(--backdrop-glass)",
+    WebkitBackdropFilter: "var(--backdrop-glass)",
+  },
+  soft: {
+    background: "var(--dialog-scrim)",
+    backdropFilter: "var(--backdrop-glass-soft)",
+    WebkitBackdropFilter: "var(--backdrop-glass-soft)",
+  },
+  plain: { background: "var(--dialog-scrim)" },
+};
+
+const SURFACE_STYLE: Record<
+  NonNullable<ModalSheetProps["surface"]>,
+  React.CSSProperties
+> = {
+  glass: {
+    background: "var(--sheet-glass-bg)",
+    color: "var(--text-default)",
+    borderColor: "var(--container-border)",
+    boxShadow: "var(--dialog-shadow)",
+    backdropFilter: "var(--backdrop-glass-strong)",
+    WebkitBackdropFilter: "var(--backdrop-glass-strong)",
+  },
+  "glass-dense": {
+    background: "var(--sheet-glass-bg)",
+    color: "var(--text-default)",
+    borderColor: "var(--container-border)",
+    boxShadow:
+      "var(--dialog-shadow), inset 0 1px 0 color-mix(in srgb, var(--overlay-text) 18%, transparent)",
+    backdropFilter: "var(--backdrop-glass-max)",
+    WebkitBackdropFilter: "var(--backdrop-glass-max)",
+  },
+  solid: {
+    background: "var(--container-bg)",
+    color: "var(--text-default)",
+    borderColor: "var(--container-border)",
+    boxShadow: "var(--dialog-shadow)",
+  },
+};
+
+export function ModalSheet({
+  open,
+  onClose,
+  ariaLabel,
+  ariaLabelledby,
+  size = "md",
+  scrim = "glass",
+  surface = "glass",
+  entry = "slide",
+  height = "auto",
+  panelClassName,
+  children,
+}: ModalSheetProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  const slide = entry === "slide";
+  const containerClass = slide
+    ? "fixed inset-0 z-(--z-modal) flex items-end justify-center overscroll-contain sm:items-center sm:px-4 sm:py-5"
+    : "fixed inset-0 z-(--z-modal) flex items-end justify-center overscroll-contain px-3 pb-3 sm:items-center sm:p-6";
+  const panelShape = slide
+    ? "rounded-t-4xl sm:rounded-4xl border-0 sm:border"
+    : "rounded-4xl border";
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className={containerClass}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          style={SCRIM_STYLE[scrim]}
+          onClick={onClose}
+        >
+          <motion.section
+            role="dialog"
+            aria-modal="true"
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
+            initial={slide ? { y: "100%" } : { y: 28, opacity: 0, scale: 0.98 }}
+            animate={slide ? { y: 0 } : { y: 0, opacity: 1, scale: 1 }}
+            exit={slide ? { y: "100%" } : { y: 20, opacity: 0, scale: 0.98 }}
+            transition={
+              slide
+                ? { type: "spring", stiffness: 350, damping: 34 }
+                : { type: "spring", stiffness: 420, damping: 34 }
+            }
+            className={`w-full ${SIZE_CLASS[size]} ${HEIGHT_CLASS[height]} ${panelShape} ${panelClassName ?? ""}`}
+            style={SURFACE_STYLE[surface]}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {children}
+          </motion.section>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/app/components/ds/RadioButton.tsx
+++ b/src/app/components/ds/RadioButton.tsx
@@ -35,7 +35,7 @@ export function RadioButton({
       disabled={disabled}
       onClick={() => onSelect?.()}
       className={[
-        "flex items-start gap-3 py-3 px-2 rounded-xl text-left active:scale-[0.98] transition-transform",
+        "flex items-start gap-3 py-3 px-2 rounded-xl text-left active:scale-98 transition-transform",
         label || description ? "w-full" : "",
         className,
       ]

--- a/src/app/components/ds/SegmentedControl.tsx
+++ b/src/app/components/ds/SegmentedControl.tsx
@@ -126,7 +126,7 @@ export function SegmentedControl<TValue extends string>({
               if (!option.disabled) onValueChange(option.value);
             }}
             className={[
-              "inline-flex min-w-0 items-center justify-center gap-1.5 active:scale-[0.98] transition-transform",
+              "inline-flex min-w-0 items-center justify-center gap-1.5 active:scale-98 transition-transform",
               fullWidth ? "flex-1" : "",
               SIZE_CLASS[size],
               ITEM_RADIUS_CLASS[radius],

--- a/src/app/components/ds/Select.tsx
+++ b/src/app/components/ds/Select.tsx
@@ -56,7 +56,7 @@ export function Select({
         type="button"
         disabled={disabled}
         onClick={() => setOpen((p) => !p)}
-        className="w-full flex items-center justify-between px-4 py-3 rounded-xl active:scale-[0.98] transition-transform"
+        className="w-full flex items-center justify-between px-4 py-3 rounded-xl active:scale-98 transition-transform"
         style={{
           background: "var(--surface-container)",
           border: open ? "2px solid var(--primary)" : "1px solid var(--outline-variant)",
@@ -141,7 +141,7 @@ export function Select({
                       onValueChange?.(opt.id);
                       setOpen(false);
                     }}
-                    className="w-full flex items-center justify-between px-4 py-2.5 text-left active:scale-[0.98] transition-transform"
+                    className="w-full flex items-center justify-between px-4 py-2.5 text-left active:scale-98 transition-transform"
                     style={{
                       background: isSelected
                         ? "color-mix(in srgb, var(--primary) 10%, rgba(0,0,0,0))"

--- a/src/app/components/ds/Stepper.tsx
+++ b/src/app/components/ds/Stepper.tsx
@@ -47,7 +47,7 @@ export function Stepper({
         size="md"
         radius="xl"
         variant="ghost"
-        className="disabled:opacity-20 active:scale-[0.88] transition-transform"
+        className="disabled:opacity-20 active:scale-88 transition-transform"
         style={buttonStyle}
         aria-label={decrementLabel}
       >
@@ -68,7 +68,7 @@ export function Stepper({
         size="md"
         radius="xl"
         variant="ghost"
-        className="disabled:opacity-20 active:scale-[0.88] transition-transform"
+        className="disabled:opacity-20 active:scale-88 transition-transform"
         style={buttonStyle}
         aria-label={incrementLabel}
       >

--- a/src/app/components/ds/index.ts
+++ b/src/app/components/ds/index.ts
@@ -52,6 +52,8 @@ export { Snackbar } from "./Snackbar";
 export type { SnackbarProps } from "./Snackbar";
 export { Dialog } from "./Dialog";
 export type { DialogProps } from "./Dialog";
+export { ModalSheet } from "./ModalSheet";
+export type { ModalSheetProps } from "./ModalSheet";
 export { BottomSheet } from "./BottomSheet";
 export type { BottomSheetProps } from "./BottomSheet";
 export { Carousel } from "./Carousel";

--- a/src/app/components/shared/search-overlay.tsx
+++ b/src/app/components/shared/search-overlay.tsx
@@ -437,8 +437,8 @@ export function SearchOverlay({
               inset: 0,
               background:
                 "color-mix(in srgb, var(--container-page) 65%, transparent)",
-              backdropFilter: "blur(20px) saturate(1.4)",
-              WebkitBackdropFilter: "blur(20px) saturate(1.4)",
+              backdropFilter: "var(--backdrop-glass)",
+              WebkitBackdropFilter: "var(--backdrop-glass)",
             }}
           />
 
@@ -692,7 +692,7 @@ export function SearchOverlay({
                                 aria-selected={isActive}
                                 onClick={() => handleSelect(item.link)}
                                 onMouseEnter={() => setActiveIndex(idx)}
-                                className="flex items-center gap-3 mx-2 px-3 py-2.5 rounded-xl cursor-pointer active:scale-[0.98] transition-transform"
+                                className="flex items-center gap-3 mx-2 px-3 py-2.5 rounded-xl cursor-pointer active:scale-98 transition-transform"
                                 style={{
                                   background: isActive
                                     ? "color-mix(in srgb, var(--primary) 8%, transparent)"

--- a/src/app/features/cooking/active-cook-widget.tsx
+++ b/src/app/features/cooking/active-cook-widget.tsx
@@ -81,7 +81,7 @@ export function ActiveCookWidget({
         whileTap={{ scale: 0.96 }}
         transition={liquidDockSpring}
         onClick={handleClick}
-        className={`fixed z-[70] inline-flex items-center rounded-full active-cook-widget ${
+        className={`fixed z-(--z-widget) inline-flex items-center rounded-full active-cook-widget ${
           active ? "is-active" : ""
         } ${compact ? "is-compact" : ""}`}
         style={{

--- a/src/app/features/cooking/cooking-mode.tsx
+++ b/src/app/features/cooking/cooking-mode.tsx
@@ -605,7 +605,7 @@ export function CookingMode() {
                 variant={isCurrent && !waiting ? "primary" : "secondary"}
                 radius="xl"
                 elevated={isCurrent && !waiting}
-                className="flex-1 flex items-center justify-center gap-2 active:scale-[0.98] transition-transform"
+                className="flex-1 flex items-center justify-center gap-2 active:scale-98 transition-transform"
                 style={{
                   height: 56,
                   borderRadius: "var(--radius-xl)",

--- a/src/app/features/dev-tools/dev-tools.tsx
+++ b/src/app/features/dev-tools/dev-tools.tsx
@@ -130,7 +130,7 @@ function LabSection({
     <Surface className="overflow-hidden" style={{ borderLeft: `3px solid ${color}` }}>
       <button
         onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between p-4 active:scale-[0.99] transition-transform"
+        className="w-full flex items-center justify-between p-4 active:scale-99 transition-transform"
         style={{ background: "transparent" }}
       >
         <div className="flex items-center gap-2.5">

--- a/src/app/features/dev-tools/engine-test-suite.tsx
+++ b/src/app/features/dev-tools/engine-test-suite.tsx
@@ -1647,7 +1647,7 @@ export function EngineTestSuite() {
               {/* Category header */}
               <button
                 onClick={() => hasResults && toggleCat(cat.id)}
-                className="w-full flex items-center justify-between p-4 active:scale-[0.99] transition-transform"
+                className="w-full flex items-center justify-between p-4 active:scale-99 transition-transform"
                 style={{ background: "transparent", cursor: hasResults ? "pointer" : "default" }}
                 disabled={!hasResults}
               >

--- a/src/app/features/dev-tools/style-editor-tab.tsx
+++ b/src/app/features/dev-tools/style-editor-tab.tsx
@@ -595,7 +595,7 @@ function ToggleField({
   return (
     <button
       onClick={() => onChange(!value)}
-      className="flex items-center gap-3 p-2.5 rounded-lg w-full active:scale-[0.98] transition-transform"
+      className="flex items-center gap-3 p-2.5 rounded-lg w-full active:scale-98 transition-transform"
       style={{
         background: value
           ? "color-mix(in srgb, var(--cta) 12%, transparent)"
@@ -662,7 +662,7 @@ function Section({
     >
       <button
         onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between p-3.5 active:scale-[0.99] transition-transform"
+        className="w-full flex items-center justify-between p-3.5 active:scale-99 transition-transform"
         style={{ background: "transparent" }}
       >
         <div className="flex items-center gap-2.5">
@@ -1712,7 +1712,7 @@ export function StyleEditorTab() {
           <button
             key={m.id}
             onClick={() => setEditorMode(m.id)}
-            className="flex items-center gap-2 flex-1 justify-center px-4 py-3 rounded-xl type-data-base active:scale-[0.98] transition-transform"
+            className="flex items-center gap-2 flex-1 justify-center px-4 py-3 rounded-xl type-data-base active:scale-98 transition-transform"
             style={{
               background: editorMode === m.id ? "var(--container-page)" : "transparent",
               color: editorMode === m.id ? "var(--text-default)" : "var(--text-muted)",
@@ -1798,7 +1798,7 @@ export function StyleEditorTab() {
         >
           <button
             onClick={() => setShowPipeline(!showPipeline)}
-            className="w-full flex items-center justify-between active:scale-[0.99] transition-transform"
+            className="w-full flex items-center justify-between active:scale-99 transition-transform"
             style={{ background: "transparent" }}
           >
             <div className="flex items-center gap-2.5">
@@ -1900,7 +1900,7 @@ export function StyleEditorTab() {
         >
           <button
             onClick={() => setShowSchema(!showSchema)}
-            className="w-full flex items-center justify-between active:scale-[0.99] transition-transform"
+            className="w-full flex items-center justify-between active:scale-99 transition-transform"
             style={{ background: "transparent" }}
           >
             <div className="flex items-center gap-2.5">
@@ -2272,7 +2272,7 @@ export function StyleEditorTab() {
         >
           <button
             onClick={() => setShowDiff(!showDiff)}
-            className="w-full flex items-center justify-between active:scale-[0.99] transition-transform"
+            className="w-full flex items-center justify-between active:scale-99 transition-transform"
             style={{ background: "transparent" }}
           >
             <div className="flex items-center gap-2.5">

--- a/src/app/features/recipe/condiment-choice-strip.tsx
+++ b/src/app/features/recipe/condiment-choice-strip.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import toppingPlaceholder from "../../../assets/toppings/_placeholder.svg";
 import { useCms } from "../cms/cms-context";
-import { IconButton } from "../../components/ds/index";
+import { IconButton, ModalSheet } from "../../components/ds/index";
 import {
   TOPPING_CONCEPTS,
   getToppingThumbnail,
@@ -319,37 +319,18 @@ export function CondimentChoiceStrip({
           aria-hidden="true"
         />
       )}
-      {!isTimeline && pickerOpen && typeof document !== "undefined"
+      {!isTimeline && typeof document !== "undefined"
           ? createPortal(
-              <motion.div
-                key="topping-choice-sheet"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.18 }}
-                className="fixed inset-0 z-[80] flex items-end justify-center px-3 pb-3 sm:items-center sm:p-6"
-                style={{ background: "var(--dialog-scrim)" }}
-                onClick={() => setPickerOpen(false)}
+              <ModalSheet
+                open={pickerOpen}
+                onClose={() => setPickerOpen(false)}
+                ariaLabel={engineMessage(cms, "topping.chooseAllTitle", "Tutti i gusti")}
+                size="lg"
+                scrim="plain"
+                surface="glass-dense"
+                entry="pop"
+                panelClassName="overflow-hidden"
               >
-                <motion.div
-                  role="dialog"
-                  aria-modal="true"
-                  aria-label={engineMessage(cms, "topping.chooseAllTitle", "Tutti i gusti")}
-                  initial={{ y: 28, opacity: 0, scale: 0.98 }}
-                  animate={{ y: 0, opacity: 1, scale: 1 }}
-                  exit={{ y: 20, opacity: 0, scale: 0.98 }}
-                  transition={{ type: "spring", stiffness: 420, damping: 34 }}
-                  className="w-full max-w-2xl overflow-hidden rounded-4xl"
-                  style={{
-                    maxHeight: "min(760px, calc(100vh - 32px))",
-                    background: "color-mix(in srgb, var(--container-page) 94%, transparent)",
-                    border: "1px solid var(--container-border)",
-                    boxShadow: "var(--dialog-shadow), inset 0 1px 0 color-mix(in srgb, var(--overlay-text) 18%, transparent)",
-                    backdropFilter: "blur(28px) saturate(1.7)",
-                    WebkitBackdropFilter: "blur(28px) saturate(1.7)",
-                  }}
-                  onClick={(event) => event.stopPropagation()}
-                >
                   <div className="flex items-start gap-3 px-4 pb-3 pt-4 sm:px-5 sm:pt-5">
                     <div className="min-w-0 flex-1">
                       <div
@@ -486,7 +467,7 @@ export function CondimentChoiceStrip({
                                 key={recipe.id}
                                 type="button"
                                 onClick={() => selectFromSheet(recipe.id)}
-                                className="flex items-center gap-3 rounded-2xl p-2.5 text-left active:scale-[0.99] transition-transform"
+                                className="flex items-center gap-3 rounded-2xl p-2.5 text-left active:scale-99 transition-transform"
                                 style={{
                                   background: active
                                     ? "var(--chip-bg-active)"
@@ -545,8 +526,7 @@ export function CondimentChoiceStrip({
                       </div>
                     </div>
                   </div>
-                </motion.div>
-              </motion.div>,
+              </ModalSheet>,
               document.body,
               "topping-choice-sheet",
             )

--- a/src/app/features/recipe/feedback-analysis.tsx
+++ b/src/app/features/recipe/feedback-analysis.tsx
@@ -298,7 +298,7 @@ function Section({
       }}
     >
       <motion.button
-        className="w-full flex items-center justify-between px-4 py-3 active:scale-[0.98]"
+        className="w-full flex items-center justify-between px-4 py-3 active:scale-98"
         onClick={() => onToggle(isOpen ? null : id)}
         style={{ background: "none", border: "none", cursor: "pointer" }}
         aria-expanded={isOpen}
@@ -439,7 +439,7 @@ function AdversarialRow({ finding }: { finding: AdversarialFinding }) {
       }}
     >
       <motion.button
-        className="w-full flex items-center gap-2 px-3 py-2 active:scale-[0.98]"
+        className="w-full flex items-center gap-2 px-3 py-2 active:scale-98"
         onClick={() => setExpanded(!expanded)}
         style={{ background: "none", border: "none", cursor: "pointer", textAlign: "left" }}
       >
@@ -448,7 +448,7 @@ function AdversarialRow({ finding }: { finding: AdversarialFinding }) {
           style={{
             fontSize: "var(--font-size-xs)",
             fontFamily: "var(--font-mono)",
-            fontWeight: 800,
+            fontWeight: "var(--weight-bold)" as any,
             letterSpacing: "0.08em",
             background: severityColors[finding.severity],
             color: "var(--overlay-text)",
@@ -520,11 +520,11 @@ function AdversarialRow({ finding }: { finding: AdversarialFinding }) {
                 {finding.description}
               </div>
               <div style={{ color: "var(--muted-foreground)" }}>
-                <span style={{ fontWeight: 600 }}>Stili:</span>{" "}
+                <span style={{ fontWeight: "var(--weight-semibold)" as any }}>Stili:</span>{" "}
                 {finding.affectedStyles.join(", ")}
               </div>
               <div style={{ color: "var(--cta)" }}>
-                <span style={{ fontWeight: 600 }}>Fix:</span>{" "}
+                <span style={{ fontWeight: "var(--weight-semibold)" as any }}>Fix:</span>{" "}
                 {finding.suggestedFix}
               </div>
             </div>

--- a/src/app/features/recipe/interpretation-narrative-card.tsx
+++ b/src/app/features/recipe/interpretation-narrative-card.tsx
@@ -5,12 +5,12 @@
  * Le storie dei maestri (badge, tecnica, narrativa) NON stanno più inline:
  * "Vedi tutte" apre una modale con tutte le interpretazioni dello stile e il
  * link alla sezione Impara. */
-import { useEffect, useState } from "react";
-import { AnimatePresence, motion } from "motion/react";
+import { useState } from "react";
 import { Check, MoreHorizontal, X } from "lucide-react";
 import { Link } from "react-router";
 import { useCms } from "../cms/cms-context";
 import type { Interpretation } from "../../data/interpretation-library";
+import { ModalSheet } from "../../components/ds/index";
 
 /** Nome primario dell'interpretazione (maestro › locale › ente › firma). */
 function primaryName(it: Interpretation): string {
@@ -184,50 +184,14 @@ function InterpretationsModal({
 }) {
   const { cms } = useCms();
 
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, onClose]);
-
   return (
-    <AnimatePresence>
-      {open && (
-        <motion.div
-          className="fixed inset-0 z-[80] flex items-end justify-center overscroll-contain sm:items-center sm:px-4 sm:py-5"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          style={{
-            background: "var(--dialog-scrim-strong)",
-            backdropFilter: "blur(20px) saturate(1.4)",
-            WebkitBackdropFilter: "blur(20px) saturate(1.4)",
-          }}
-          onClick={onClose}
-        >
-          <motion.section
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="inspiration-modal-title"
-            initial={{ y: "100%" }}
-            animate={{ y: 0 }}
-            exit={{ y: "100%" }}
-            transition={{ type: "spring", stiffness: 350, damping: 34 }}
-            className="w-full max-h-[85dvh] sm:max-h-[80vh] sm:max-w-[640px] rounded-t-4xl sm:rounded-4xl border-0 sm:border overflow-hidden flex flex-col"
-            style={{
-              background:
-                "color-mix(in srgb, var(--container-page) 94%, transparent)",
-              color: "var(--text-default)",
-              borderColor: "var(--container-border)",
-              boxShadow: "var(--dialog-shadow)",
-              backdropFilter: "blur(24px) saturate(1.6)",
-              WebkitBackdropFilter: "blur(24px) saturate(1.6)",
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
+    <ModalSheet
+      open={open}
+      onClose={onClose}
+      ariaLabelledby="inspiration-modal-title"
+      size="md"
+      panelClassName="overflow-hidden flex flex-col"
+    >
             <div
               className="flex-shrink-0 flex items-center gap-3 px-5 py-3.5 sm:px-6 border-b"
               style={{ borderColor: "var(--container-border-subtle)" }}
@@ -298,10 +262,7 @@ function InterpretationsModal({
                 {cms.misc.inspirationLearnLink ?? "Scopri di più nella sezione Impara"} →
               </Link>
             </div>
-          </motion.section>
-        </motion.div>
-      )}
-    </AnimatePresence>
+    </ModalSheet>
   );
 }
 
@@ -337,7 +298,7 @@ function InterpretationNarrativeCard({
             },
           }
         : {})}
-      className={`relative rounded-2xl p-4 ${selectable ? "cursor-pointer transition-all active:scale-[0.99]" : ""}`}
+      className={`relative rounded-2xl p-4 ${selectable ? "cursor-pointer transition-all active:scale-99" : ""}`}
       style={{
         background: selected
           ? "color-mix(in srgb, var(--primary) 6%, var(--container-card))"

--- a/src/app/features/recipe/procedure-hero.tsx
+++ b/src/app/features/recipe/procedure-hero.tsx
@@ -112,7 +112,7 @@ export function ProcedureHeroControls({
           <div className="mt-2 flex items-center gap-1 sm:gap-1.5">
             <button
               onClick={() => setStartTime((s) => shiftQuarter(s, -1))}
-              className="w-8 h-8 rounded-xl flex items-center justify-center active:scale-[0.9] transition-transform"
+              className="w-8 h-8 rounded-xl flex items-center justify-center active:scale-90 transition-transform"
               style={{
                 background: "var(--recipe-bg)",
                 border: "1px solid var(--recipe-border)",
@@ -185,7 +185,7 @@ export function ProcedureHeroControls({
             )}
             <button
               onClick={() => setStartTime((s) => shiftQuarter(s, 1))}
-              className="w-8 h-8 rounded-xl flex items-center justify-center active:scale-[0.9] transition-transform"
+              className="w-8 h-8 rounded-xl flex items-center justify-center active:scale-90 transition-transform"
               style={{
                 background: "var(--recipe-bg)",
                 border: "1px solid var(--recipe-border)",
@@ -217,7 +217,7 @@ export function ProcedureHeroControls({
           <div className="mt-2 flex items-center gap-1 sm:gap-1.5">
             <button
               onClick={() => setStartTime((s) => shiftQuarter(s, -1))}
-              className="w-8 h-8 rounded-xl flex items-center justify-center active:scale-[0.9] transition-transform"
+              className="w-8 h-8 rounded-xl flex items-center justify-center active:scale-90 transition-transform"
               style={{
                 background: "var(--recipe-bg)",
                 border: "1px solid var(--recipe-border)",
@@ -291,7 +291,7 @@ export function ProcedureHeroControls({
             )}
             <button
               onClick={() => setStartTime((s) => shiftQuarter(s, 1))}
-              className="w-8 h-8 rounded-xl flex items-center justify-center active:scale-[0.9] transition-transform"
+              className="w-8 h-8 rounded-xl flex items-center justify-center active:scale-90 transition-transform"
               style={{
                 background: "var(--recipe-bg)",
                 border: "1px solid var(--recipe-border)",
@@ -324,7 +324,7 @@ export function ProcedureHeroControls({
                 newStart.setFullYear(targetDate.getFullYear(), targetDate.getMonth(), targetDate.getDate());
                 setStartTime(roundToQuarter(newStart));
               }}
-              className="flex-1 py-1.5 px-2.5 rounded-xl text-center text-xs font-semibold active:scale-[0.97] transition-all"
+              className="flex-1 py-1.5 px-2.5 rounded-xl text-center text-xs font-semibold active:scale-97 transition-all"
               style={{
                 background: isSelected ? "var(--chip-bg-active)" : "var(--container-bg-low)",
                 border: isSelected ? "1px solid var(--tertiary)" : "1px solid var(--container-border-subtle)",
@@ -341,7 +341,7 @@ export function ProcedureHeroControls({
       {/* Smart Eating Planner Shortcuts */}
       <div className="mt-4 pt-3.5" style={{ borderTop: "1px solid var(--container-border-subtle)" }}>
         <div
-          className="text-[10px] font-bold tracking-wider uppercase mb-2"
+          className="text-2xs font-bold tracking-wider uppercase mb-2"
           style={{ color: "var(--text-muted)", letterSpacing: "var(--tracking-spread)" }}
         >
           Pronto per il pasto:

--- a/src/app/features/recipe/recipe-configurator.tsx
+++ b/src/app/features/recipe/recipe-configurator.tsx
@@ -76,7 +76,7 @@ export function PremiumSelect({
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className={`w-full flex items-center gap-2.5 px-4 py-3 rounded-xl text-left active:scale-[0.99] transition-all border
+        className={`w-full flex items-center gap-2.5 px-4 py-3 rounded-xl text-left active:scale-99 transition-all border
           ${open 
             ? "border-[var(--tertiary)] shadow-[0_0_0_1px_color-mix(in_srgb,var(--tertiary)_15%,transparent)]" 
             : "border-[var(--outline-variant)] hover:border-[var(--tertiary)]"
@@ -153,7 +153,7 @@ export function PremiumSelect({
                     />
                   )}
                   <div
-                    className="px-3 py-1 text-[10px] font-bold tracking-wider"
+                    className="px-3 py-1 text-2xs font-bold tracking-wider"
                     style={{
                       color: "var(--text-muted)",
                       textTransform: "uppercase",
@@ -235,7 +235,7 @@ function PremiumSelectRow({
       </div>
       {option.suggested && (
         <span
-          className="px-1.5 py-0.5 rounded text-[10px] font-semibold flex-shrink-0 mr-1"
+          className="px-1.5 py-0.5 rounded text-2xs font-semibold flex-shrink-0 mr-1"
           style={{
             background: active ? "color-mix(in srgb, var(--overlay-text) 20%, transparent)" : "color-mix(in srgb, var(--tertiary) 15%, transparent)",
             color: active ? "inherit" : "var(--tertiary)",
@@ -605,7 +605,7 @@ export function RecipeConfigurator({
       {/* Smart Link — barra compatta, singolo tap-target */}
       <button
         onClick={() => setSmartLink(!smartLink)}
-        className="flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl text-left active:scale-[0.99] transition-all"
+        className="flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl text-left active:scale-99 transition-all"
         style={{
           background: smartLink ? "color-mix(in srgb, var(--tertiary) 8%, transparent)" : "var(--surface-container)",
           border: smartLink ? "1.5px solid var(--tertiary)" : "1px solid var(--outline-variant)",
@@ -1254,7 +1254,7 @@ function BeginnerFlourPicker({
               key={f.label}
               type="button"
               onClick={() => onChange(f.w)}
-              className="flex-1 rounded-xl px-2 py-2.5 text-left transition-all active:scale-[0.98]"
+              className="flex-1 rounded-xl px-2 py-2.5 text-left transition-all active:scale-98"
               style={{
                 background: active ? "color-mix(in srgb, var(--tertiary) 12%, transparent)" : "var(--surface-container)",
                 border: active ? "1.5px solid var(--tertiary)" : "1px solid var(--outline-variant)",

--- a/src/app/features/recipe/recipe-feedback.tsx
+++ b/src/app/features/recipe/recipe-feedback.tsx
@@ -241,7 +241,7 @@ export function RecipeFeedbackForm({ recipe, skillLevel }: RecipeFeedbackFormPro
         }}
       >
         <div>
-          <div style={{ color: "var(--text-default)", fontSize: "var(--font-size-xl)", fontWeight: 600 }}>
+          <div style={{ color: "var(--text-default)", fontSize: "var(--font-size-xl)", fontWeight: "var(--weight-semibold)" as any }}>
             {cms.feedback.triedQuestion}
           </div>
           <div className="type-body" style={{ color: "var(--muted-foreground)", marginTop: "var(--space-0-5)" }}>
@@ -260,7 +260,7 @@ export function RecipeFeedbackForm({ recipe, skillLevel }: RecipeFeedbackFormPro
               border: "1px solid var(--outline-variant)",
               color: "var(--text-default)",
               fontSize: "0.8125rem",
-              fontWeight: 600,
+              fontWeight: "var(--weight-semibold)" as any,
               cursor: "pointer",
             }}
           >
@@ -278,7 +278,7 @@ export function RecipeFeedbackForm({ recipe, skillLevel }: RecipeFeedbackFormPro
               border: "1px solid var(--outline-variant)",
               color: "var(--text-default)",
               fontSize: "0.8125rem",
-              fontWeight: 600,
+              fontWeight: "var(--weight-semibold)" as any,
               cursor: "pointer",
             }}
           >
@@ -301,7 +301,7 @@ export function RecipeFeedbackForm({ recipe, skillLevel }: RecipeFeedbackFormPro
         }}
       >
         <div>
-          <div style={{ color: "var(--text-default)", fontSize: "var(--font-size-xl)", fontWeight: 600 }}>
+          <div style={{ color: "var(--text-default)", fontSize: "var(--font-size-xl)", fontWeight: "var(--weight-semibold)" as any }}>
             {cms.feedback.detailedPrompt}
           </div>
           <div className="type-body" style={{ color: "var(--muted-foreground)", marginTop: "var(--space-0-5)" }}>
@@ -316,7 +316,7 @@ export function RecipeFeedbackForm({ recipe, skillLevel }: RecipeFeedbackFormPro
               background: "var(--cta)",
               color: "var(--overlay-text)",
               fontSize: "var(--font-size-md)",
-              fontWeight: 600,
+              fontWeight: "var(--weight-semibold)" as any,
               cursor: "pointer",
               border: "none",
             }}
@@ -331,7 +331,7 @@ export function RecipeFeedbackForm({ recipe, skillLevel }: RecipeFeedbackFormPro
               border: "1px solid var(--outline-variant)",
               color: "var(--text-muted)",
               fontSize: "var(--font-size-md)",
-              fontWeight: 600,
+              fontWeight: "var(--weight-semibold)" as any,
               cursor: "pointer",
             }}
           >
@@ -355,7 +355,7 @@ export function RecipeFeedbackForm({ recipe, skillLevel }: RecipeFeedbackFormPro
         style={{ borderBottom: "1px solid var(--outline-variant)" }}
       >
         <div>
-          <span className="type-body-lg" style={{ color: "var(--text-default)", fontWeight: 600 }}>
+          <span className="type-body-lg" style={{ color: "var(--text-default)", fontWeight: "var(--weight-semibold)" as any }}>
             {cms.feedback.detailedTitle}
           </span>
           <span className="type-body-sm" style={{ display: "block", color: "var(--muted-foreground)", marginTop: "var(--space-0-5)" }}>
@@ -447,7 +447,7 @@ export function RecipeFeedbackForm({ recipe, skillLevel }: RecipeFeedbackFormPro
             border: "none",
             cursor: overall !== null ? "pointer" : "not-allowed",
             fontSize: "var(--font-size-lg)",
-            fontWeight: 600,
+            fontWeight: "var(--weight-semibold)" as any,
             opacity: overall !== null ? 1 : 0.5,
             transition: "background 0.15s, opacity 0.15s",
           }}
@@ -466,7 +466,7 @@ function FieldLabel({ label, optional, hint }: { label: string; optional?: boole
   const { cms } = useCms();
   return (
     <div className="flex items-center gap-2">
-      <span className="type-body" style={{ color: "var(--text-default)", fontWeight: 600 }}>
+      <span className="type-body" style={{ color: "var(--text-default)", fontWeight: "var(--weight-semibold)" as any }}>
         {label}
       </span>
       {optional && (

--- a/src/app/features/recipe/recipe-learning-panel.tsx
+++ b/src/app/features/recipe/recipe-learning-panel.tsx
@@ -1,8 +1,8 @@
-import { AnimatePresence, motion } from "motion/react";
 import { X, GraduationCap } from "lucide-react";
 import type { PizzaStyle } from "../../domain/pizza-engine";
 import { formatOrigin } from "../../domain/pizza-engine";
 import { useCms } from "../cms/cms-context";
+import { ModalSheet } from "../../components/ds/index";
 
 export function RecipeLearningPanel({
   open,
@@ -17,37 +17,16 @@ export function RecipeLearningPanel({
 }) {
   const { cms } = useCms();
   return (
-    <AnimatePresence>
-      {open && (
-        <motion.div
-          className="fixed inset-0 z-[80] flex items-end justify-center sm:items-center px-4 py-5"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          style={{
-            background: "var(--dialog-scrim)",
-            backdropFilter: "blur(10px)",
-            WebkitBackdropFilter: "blur(10px)",
-          }}
-          onClick={onClose}
-        >
-          <motion.section
-            role="dialog"
-            aria-modal="true"
-            aria-label={`Approfondimenti su ${style.name}`}
-            initial={{ y: 28, opacity: 0, scale: 0.98 }}
-            animate={{ y: 0, opacity: 1, scale: 1 }}
-            exit={{ y: 22, opacity: 0, scale: 0.98 }}
-            transition={{ type: "spring", stiffness: 420, damping: 34 }}
-            className="w-full max-w-2xl rounded-3xl overflow-hidden"
-            style={{
-              background: "var(--container-bg)",
-              color: "var(--text-default)",
-              border: "1px solid var(--container-border)",
-              boxShadow: "var(--dialog-shadow)",
-            }}
-            onClick={(event) => event.stopPropagation()}
-          >
+    <ModalSheet
+      open={open}
+      onClose={onClose}
+      ariaLabel={`Approfondimenti su ${style.name}`}
+      size="lg"
+      scrim="soft"
+      surface="solid"
+      entry="pop"
+      panelClassName="overflow-hidden"
+    >
             <div
               className="flex items-start gap-4 px-5 py-5 sm:px-6"
               style={{ borderBottom: "1px solid var(--container-border-subtle)" }}
@@ -131,9 +110,6 @@ export function RecipeLearningPanel({
                 ))}
               </div>
             </div>
-          </motion.section>
-        </motion.div>
-      )}
-    </AnimatePresence>
+    </ModalSheet>
   );
 }

--- a/src/app/features/recipe/recipe-match-card.tsx
+++ b/src/app/features/recipe/recipe-match-card.tsx
@@ -769,7 +769,7 @@ function ScoreBar({
         ? { type: "button" as const, onClick: onToggleExplain, "aria-expanded": explained }
         : {})}
       className={`${compact ? "grow shrink-0 basis-[140px] min-w-[140px]" : "min-w-[148px] flex-1"} ${
-        explainable ? "text-left active:scale-[0.985] transition-transform" : ""
+        explainable ? "text-left active:scale-98 transition-transform" : ""
       }`}
       style={explainable ? { background: "transparent", border: "none", padding: 0, cursor: "pointer" } : undefined}
     >

--- a/src/app/features/recipe/recipe-output-bits.tsx
+++ b/src/app/features/recipe/recipe-output-bits.tsx
@@ -1,13 +1,14 @@
 /* ═══ RECIPE OUTPUT — componenti di supporto (estratti lug 2026) ═══
  * NerdAuraBlock, ScrollToTopOnMount, IngRow, GlossaryWLink. */
 
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router";
 import { X } from "lucide-react";
 import { GLOSSARY_TERMS } from "../../data/glossary-data";
 import { useCms } from "../cms/cms-context";
+import { ModalSheet } from "../../components/ds/index";
 
 export function NerdAuraBlock({
   children,
@@ -48,7 +49,7 @@ export function NerdAuraBlock({
             "radial-gradient(ellipse at 18% 18%, color-mix(in srgb, var(--logo-grad-start) 42%, transparent) 0%, transparent 58%), radial-gradient(ellipse at 82% 30%, color-mix(in srgb, var(--logo-grad-mid) 36%, transparent) 0%, transparent 54%), radial-gradient(ellipse at 48% 92%, color-mix(in srgb, var(--logo-grad-end) 34%, transparent) 0%, transparent 62%)",
         }}
       />
-      <div className="relative z-[1]">{children}</div>
+      <div className="relative z-1">{children}</div>
     </div>
   );
 }
@@ -137,15 +138,6 @@ export function GlossaryWLink({ w }: { w: number }) {
   const { cms } = useCms();
   const term = GLOSSARY_TERMS.find((t) => t.id === "w_alveograph");
 
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open]);
-
   if (!term) return <>W{w}</>;
 
   const inRange = (value: string) => {
@@ -176,40 +168,13 @@ export function GlossaryWLink({ w }: { w: number }) {
         W{w}
       </button>
       {createPortal(
-        <AnimatePresence>
-          {open && (
-            <motion.div
-              className="fixed inset-0 z-[80] flex items-end justify-center overscroll-contain sm:items-center sm:px-4 sm:py-5"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              style={{
-                background: "var(--dialog-scrim-strong)",
-                backdropFilter: "blur(20px) saturate(1.4)",
-                WebkitBackdropFilter: "blur(20px) saturate(1.4)",
-              }}
-              onClick={() => setOpen(false)}
-            >
-              <motion.section
-                role="dialog"
-                aria-modal="true"
-                aria-label={term.name}
-                initial={{ y: "100%" }}
-                animate={{ y: 0 }}
-                exit={{ y: "100%" }}
-                transition={{ type: "spring", stiffness: 350, damping: 34 }}
-                className="w-full max-h-[80dvh] sm:max-w-[440px] rounded-t-4xl sm:rounded-4xl border-0 sm:border overflow-y-auto overscroll-contain px-5 py-4 sm:px-6 sm:py-5"
-                style={{
-                  background:
-                    "color-mix(in srgb, var(--container-page) 94%, transparent)",
-                  color: "var(--text-default)",
-                  borderColor: "var(--container-border)",
-                  boxShadow: "var(--dialog-shadow)",
-                  backdropFilter: "blur(24px) saturate(1.6)",
-                  WebkitBackdropFilter: "blur(24px) saturate(1.6)",
-                }}
-                onClick={(e) => e.stopPropagation()}
-              >
+        <ModalSheet
+          open={open}
+          onClose={() => setOpen(false)}
+          ariaLabel={term.name}
+          size="sm"
+          panelClassName="overflow-y-auto overscroll-contain px-5 py-4 sm:px-6 sm:py-5"
+        >
                 <div className="flex items-start gap-3">
                   <h3
                     className="flex-1 min-w-0"
@@ -316,10 +281,7 @@ export function GlossaryWLink({ w }: { w: number }) {
                 >
                   {cms.cooking.learnMore} →
                 </Link>
-              </motion.section>
-            </motion.div>
-          )}
-        </AnimatePresence>,
+        </ModalSheet>,
         document.body,
       )}
     </>

--- a/src/app/features/recipe/recipe-setup-panel.tsx
+++ b/src/app/features/recipe/recipe-setup-panel.tsx
@@ -5,7 +5,7 @@ import {
   Sparkles,
   X,
 } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { motion } from "motion/react";
 import {
   useEffect,
   useMemo,
@@ -13,7 +13,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { CtaButton } from "../../components/ds/index";
+import { CtaButton, ModalSheet } from "../../components/ds/index";
 import { useCms, type CmsContent } from "../cms/cms-context";
 import { createFormatter, formatTemperatureCopy, t } from "../cms/i18n";
 import { SpecCell } from "./recipe-stat-strip";
@@ -185,15 +185,6 @@ export function RecipeSetupPanel({
     return () => window.clearTimeout(timeout);
   }, [notice, onNotice]);
 
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, setOpen]);
-
   const interpretations = useMemo(
     () => getInterpretationsForStyle(style.id),
     [style.id],
@@ -253,7 +244,7 @@ export function RecipeSetupPanel({
            Solo la leva ha aspetto cliccabile. */
         <button
           onClick={() => (onRequestOpen ? onRequestOpen() : setOpen(true))}
-          className="w-full flex flex-wrap items-baseline gap-x-2.5 gap-y-0.5 px-0.5 py-1 text-left active:scale-[0.995] transition-transform"
+          className="w-full flex flex-wrap items-baseline gap-x-2.5 gap-y-0.5 px-0.5 py-1 text-left active:scale-99 transition-transform"
           style={{
             background: "transparent",
             border: "none",
@@ -307,7 +298,7 @@ export function RecipeSetupPanel({
       >
         <button
           onClick={() => (onRequestOpen ? onRequestOpen() : setOpen(true))}
-          className="w-full flex items-center gap-3 px-5 py-4 text-left active:scale-[0.99] transition-all duration-200 hover:bg-[color-mix(in srgb,var(--text-default)_2%,transparent)] group"
+          className="w-full flex items-center gap-3 px-5 py-4 text-left active:scale-99 transition-all duration-200 hover:bg-[color-mix(in srgb,var(--text-default)_2%,transparent)] group"
           style={{
             background: "transparent",
             border: "none",
@@ -372,40 +363,14 @@ export function RecipeSetupPanel({
       </div>
       )}
 
-      <AnimatePresence>
-        {open && (
-          <motion.div
-            className="fixed inset-0 z-[80] flex items-end justify-center overscroll-contain sm:items-center sm:px-4 sm:py-5"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            style={{
-              background: "var(--dialog-scrim-strong)",
-              backdropFilter: "blur(20px) saturate(1.4)",
-              WebkitBackdropFilter: "blur(20px) saturate(1.4)",
-            }}
-            onClick={() => setOpen(false)}
-          >
-            <motion.section
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="recipe-setup-title"
-              initial={{ y: "100%" }}
-              animate={{ y: 0 }}
-              exit={{ y: "100%" }}
-              transition={{ type: "spring", stiffness: 350, damping: 34 }}
-              className="w-full h-[92dvh] max-h-[92dvh] sm:h-[min(760px,88vh)] sm:max-h-[88vh] sm:max-w-[1160px] rounded-t-4xl sm:rounded-4xl border-0 sm:border overflow-hidden flex flex-col"
-              style={{
-                background:
-                  "color-mix(in srgb, var(--container-page) 92%, transparent)",
-                color: "var(--text-default)",
-                borderColor: "var(--container-border)",
-                boxShadow: "var(--dialog-shadow)",
-                backdropFilter: "blur(24px) saturate(1.6)",
-                WebkitBackdropFilter: "blur(24px) saturate(1.6)",
-              }}
-              onClick={(e) => e.stopPropagation()}
-            >
+      <ModalSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        ariaLabelledby="recipe-setup-title"
+        size="xl"
+        height="full"
+        panelClassName="overflow-hidden flex flex-col"
+      >
               <div
                 className="flex-shrink-0 px-5 py-3 sm:px-7 sm:py-3.5 border-b"
                 style={{ borderColor: "var(--container-border-subtle)" }}
@@ -662,16 +627,13 @@ export function RecipeSetupPanel({
                 <CtaButton
                   type="button"
                   onClick={() => setOpen(false)}
-                  className="w-full sm:w-auto px-7 py-3 active:scale-[0.98]"
+                  className="w-full sm:w-auto px-7 py-3 active:scale-98"
                   style={{ fontSize: "var(--font-size-lg)" }}
                 >
                   {cmsMessage(cms, "recipeSetup.done", "Fatto")}
                 </CtaButton>
               </div>
-            </motion.section>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      </ModalSheet>
     </section>
   );
 }

--- a/src/app/features/recipe/recipe-view.tsx
+++ b/src/app/features/recipe/recipe-view.tsx
@@ -281,8 +281,8 @@ export function RecipeView({
           style={{
             background:
               "color-mix(in srgb, var(--container-page) 88%, transparent)",
-            backdropFilter: "blur(24px) saturate(1.6)",
-            WebkitBackdropFilter: "blur(24px) saturate(1.6)",
+            backdropFilter: "var(--backdrop-glass-strong)",
+            WebkitBackdropFilter: "var(--backdrop-glass-strong)",
             borderBottom:
               "1px solid var(--container-border-subtle)",
             /* Notch / status bar (Safari iOS, PWA, landscape) */

--- a/src/app/features/recipe/recommended-styles.tsx
+++ b/src/app/features/recipe/recommended-styles.tsx
@@ -688,7 +688,7 @@ function StyleCard({
           y: isSelected ? 0 : -4,
           transition: { type: "spring", stiffness: 500, damping: 30 },
         }}
-        className="relative text-left group w-full active:scale-[0.97]"
+        className="relative text-left group w-full active:scale-97"
         style={{ transformOrigin: "center bottom" }}
       >
         {/* Tilt 3D: la card si inclina verso il puntatore col riflesso caldo */}
@@ -727,7 +727,7 @@ function StyleCard({
                 src={photo}
                 alt={style.name}
                 loading="lazy"
-                className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.05]"
+                className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-105"
               />
             </motion.div>
 

--- a/src/app/features/recipe/style-detail-sheet.tsx
+++ b/src/app/features/recipe/style-detail-sheet.tsx
@@ -563,7 +563,7 @@ export function StyleDetailSheet({
             onClick={onGenerate}
             whileHover={{ scale: 1.02 }}
             deepShadow
-            className="w-full h-13 mt-6 active:scale-[0.97]"
+            className="w-full h-13 mt-6 active:scale-97"
           >
             <Sparkles size={15} />
             {pt.sheetGenerateBtn}

--- a/src/app/features/recipe/user-needs.tsx
+++ b/src/app/features/recipe/user-needs.tsx
@@ -432,7 +432,7 @@ function SettingsSummaryBar({
           <button
             key={tab.id}
             onClick={() => onTabSelect(isActive ? null : tab.id)}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full transition-all active:scale-[0.97]"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full transition-all active:scale-97"
             style={{
               background: isActive
                 ? "var(--chip-bg-active)"
@@ -479,7 +479,7 @@ function SettingsSummaryBar({
             }}
             onClick={onChangeTime}
             aria-pressed={timeActive}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full active:scale-[0.97]"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full active:scale-97"
             style={{
               background: timeColors.bg,
               color: timeColors.text,
@@ -704,7 +704,7 @@ export function UserNeeds({
                         <Thermometer size={16} style={{ color: "var(--needs-pantry-accent)" }} />
                         <button
                           onClick={() => { setKitchenTempManual(true); setKitchenTemp((prev) => Math.max(10, prev - 1)); }}
-                          className="w-8 h-8 rounded-lg flex items-center justify-center active:scale-[0.88] transition-transform text-lg"
+                          className="w-8 h-8 rounded-lg flex items-center justify-center active:scale-88 transition-transform text-lg"
                           style={{ background: "var(--needs-oven-bg)", border: "1px solid var(--needs-oven-border)" }}
                           aria-label={cms.misc.kitchenTempDown}
                         >
@@ -715,7 +715,7 @@ export function UserNeeds({
                         </span>
                         <button
                           onClick={() => { setKitchenTempManual(true); setKitchenTemp((prev) => Math.min(40, prev + 1)); }}
-                          className="w-8 h-8 rounded-lg flex items-center justify-center active:scale-[0.88] transition-transform text-lg"
+                          className="w-8 h-8 rounded-lg flex items-center justify-center active:scale-88 transition-transform text-lg"
                           style={{ background: "var(--needs-oven-bg)", border: "1px solid var(--needs-oven-border)" }}
                           aria-label={cms.misc.kitchenTempUp}
                         >
@@ -760,7 +760,7 @@ export function UserNeeds({
                             <motion.button
                               key={preset.id}
                               onClick={() => handleOvenSelect(preset.id, preset.maxTemp)}
-                              className={compact ? "flex items-center gap-2.5 px-3 py-2.5 rounded-xl transition-all text-left active:scale-[0.96]" : "flex items-center gap-3 px-4 py-3.5 rounded-xl transition-all text-left active:scale-[0.96]"}
+                              className={compact ? "flex items-center gap-2.5 px-3 py-2.5 rounded-xl transition-all text-left active:scale-96" : "flex items-center gap-3 px-4 py-3.5 rounded-xl transition-all text-left active:scale-96"}
                               style={{
                                 background: active ? "var(--chip-bg-active)" : "var(--chip-bg)",
                                 color: active ? "var(--chip-text-active)" : "var(--chip-text)",
@@ -968,8 +968,8 @@ function TimeSlotPicker({
               onClick={() => onTimeSlotChange(slot)}
               className={
                 compact
-                  ? "relative flex items-center justify-between px-3 py-2.5 rounded-xl transition-all active:scale-[0.98] text-left w-full"
-                  : "relative flex items-center justify-between px-4 py-3.5 rounded-2xl transition-all active:scale-[0.98] text-left w-full"
+                  ? "relative flex items-center justify-between px-3 py-2.5 rounded-xl transition-all active:scale-98 text-left w-full"
+                  : "relative flex items-center justify-between px-4 py-3.5 rounded-2xl transition-all active:scale-98 text-left w-full"
               }
               style={{
                 background: active
@@ -1043,7 +1043,7 @@ function TimeSlotPicker({
                 )}
                 {active && (
                   <span
-                    className="px-2 py-0.5 rounded-full text-[10px] flex-shrink-0"
+                    className="px-2 py-0.5 rounded-full text-2xs flex-shrink-0"
                     style={{
                       background: "color-mix(in srgb, var(--overlay-text) 25%, transparent)",
                       color: "var(--overlay-text)",
@@ -1124,7 +1124,7 @@ function TimeSlotPicker({
               {suggested && !compact && (
                 <div className="absolute top-2 inset-x-0 flex justify-center z-10">
                   <span
-                    className="px-2 py-0.5 rounded-full text-[10px]"
+                    className="px-2 py-0.5 rounded-full text-2xs"
                     style={{
                       background: colors.bg,
                       color: "var(--overlay-text)",
@@ -1189,7 +1189,7 @@ function TimeSlotPicker({
               {active && (
                 <div className={compact ? "absolute top-2 right-2" : "absolute top-2.5 right-2.5"}>
                   <span
-                    className="px-2 py-0.5 rounded-full text-[10px]"
+                    className="px-2 py-0.5 rounded-full text-2xs"
                     style={{
                       background: "color-mix(in srgb, var(--overlay-text) 25%, transparent)",
                       color: "var(--overlay-text)",

--- a/src/app/pages/cms.tsx
+++ b/src/app/pages/cms.tsx
@@ -164,7 +164,7 @@ export function CmsPage() {
         style={{
           background:
             "color-mix(in srgb, var(--container-page) 88%, transparent)",
-          backdropFilter: "blur(24px) saturate(1.6)",
+          backdropFilter: "var(--backdrop-glass-strong)",
           borderBottom: "1px solid var(--border-muted)",
         }}
       >
@@ -462,7 +462,7 @@ export function CmsPage() {
             onClick={() =>
               setMobileSidebarOpen(!mobileSidebarOpen)
             }
-            className="w-full flex items-center justify-between px-4 py-3 active:scale-[0.99]"
+            className="w-full flex items-center justify-between px-4 py-3 active:scale-99"
             style={{
               background: "var(--surface-container-low)",
               borderBottom: "1px solid var(--border-muted)",
@@ -583,7 +583,7 @@ function SidebarContent({
           <button
             key={s.id}
             onClick={() => onSelect(s.id)}
-            className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-left active:scale-[0.98] transition-transform"
+            className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-left active:scale-98 transition-transform"
             style={{
               background: isActive
                 ? "var(--container-page)"
@@ -1233,7 +1233,7 @@ function LocaleSwitcher() {
                 if (meta.available) switchLocale(meta.id);
               }}
               disabled={!meta.available}
-              className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-left active:scale-[0.97] transition-transform disabled:opacity-40 disabled:cursor-not-allowed"
+              className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-left active:scale-97 transition-transform disabled:opacity-40 disabled:cursor-not-allowed"
               style={{
                 background: isActive
                   ? "color-mix(in srgb, var(--primary) 12%, var(--container-page))"

--- a/src/app/pages/explore.tsx
+++ b/src/app/pages/explore.tsx
@@ -92,7 +92,7 @@ function FeaturedRecipeCard({
     <Link
       to={linkTo}
       state={{ exploreBackTo }}
-      className="flex flex-col md:flex-row overflow-hidden rounded-3xl active:scale-[0.99] transition-all duration-300 group"
+      className="flex flex-col md:flex-row overflow-hidden rounded-3xl active:scale-99 transition-all duration-300 group"
       style={{
         textDecoration: "none",
         color: "inherit",
@@ -114,7 +114,7 @@ function FeaturedRecipeCard({
         <ImageWithFallback
           src={photo}
           alt={recipe.name}
-          className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.04]"
+          className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-104"
           loading="lazy"
         />
         {/* Badge autenticità posizionato sull'immagine */}
@@ -699,7 +699,7 @@ function SignatureRecipeCard({
         <Link
           to={linkTo}
           state={{ exploreBackTo }}
-          className="block rounded-2xl overflow-hidden active:scale-[0.97] transition-transform group"
+          className="block rounded-2xl overflow-hidden active:scale-97 transition-transform group"
           style={{
             background: "var(--container-card)",
             border: isNerd ? "1px solid color-mix(in srgb, var(--accent-nerd) 25%, transparent)" : "1px solid var(--container-border-ghost)",
@@ -714,7 +714,7 @@ function SignatureRecipeCard({
           <ImageWithFallback
             src={photo}
             alt={recipe.name}
-            className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.05]"
+            className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-105"
             loading="lazy"
           />
           <div
@@ -846,7 +846,7 @@ function StyleCatalogCard({
         <Link
           to={`/recipe/${style.id}?mode=canonical`}
           state={{ exploreBackTo }}
-          className="block rounded-2xl overflow-hidden active:scale-[0.97] transition-transform group"
+          className="block rounded-2xl overflow-hidden active:scale-97 transition-transform group"
           style={{
             background: "var(--container-card)",
             border: isNerd ? "1px solid color-mix(in srgb, var(--accent-nerd) 25%, transparent)" : "1px solid var(--container-border-ghost)",
@@ -862,7 +862,7 @@ function StyleCatalogCard({
           <ImageWithFallback
             src={photo}
             alt={style.name}
-            className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.05]"
+            className="w-full h-full object-cover transition-transform duration-700 ease-out group-hover:scale-105"
             loading="lazy"
           />
 

--- a/src/app/pages/glossary.tsx
+++ b/src/app/pages/glossary.tsx
@@ -452,7 +452,7 @@ function TermCard({
     >
       <motion.button
         onClick={onToggle}
-        className="w-full flex items-start gap-3 px-4 py-3.5 active:scale-[0.995] text-left"
+        className="w-full flex items-start gap-3 px-4 py-3.5 active:scale-99 text-left"
       >
         <div
           className="w-8 h-8 rounded-xl flex items-center justify-center flex-shrink-0 mt-0.5"

--- a/src/app/pages/home.tsx
+++ b/src/app/pages/home.tsx
@@ -1094,7 +1094,7 @@ export function HomePage() {
         href="#main-content"
         radius="lg"
         elevated={false}
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[9999] focus:px-4 focus:py-2 focus:rounded-lg"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-(--z-skiplink) focus:px-4 focus:py-2 focus:rounded-lg"
         style={{
           fontSize: "var(--font-size-lg)",
           fontWeight: "var(--weight-semibold)" as any,
@@ -1986,7 +1986,7 @@ export function HomePage() {
               onClick={handleGenerateRecipe}
               whileHover={{ scale: 1.03, y: -1 }}
               deepShadow
-              className="pointer-events-auto h-12 sm:h-13 px-8 sm:px-10 active:scale-[0.97]"
+              className="pointer-events-auto h-12 sm:h-13 px-8 sm:px-10 active:scale-97"
             >
               <Sparkles size={15} />
               {cms.ui.generate}

--- a/src/app/pages/learn.tsx
+++ b/src/app/pages/learn.tsx
@@ -255,7 +255,7 @@ export function LearnPage() {
           </div>
           <Link
             to={`/recipe/${path.styleId}?mode=adapted`}
-            className="block relative overflow-hidden rounded-3xl active:scale-[0.99] transition-all duration-300 group"
+            className="block relative overflow-hidden rounded-3xl active:scale-99 transition-all duration-300 group"
             style={{
               textDecoration: "none",
               color: "var(--overlay-text)",
@@ -376,7 +376,7 @@ export function LearnPage() {
 
           <Link
             to="/learn/glossary"
-            className="block rounded-2xl active:scale-[0.99] transition-all duration-300 group"
+            className="block rounded-2xl active:scale-99 transition-all duration-300 group"
             style={{
               textDecoration: "none",
               color: "inherit",
@@ -517,7 +517,7 @@ export function LearnPage() {
                 >
                   <Link
                     to={section.to + linkSearch}
-                    className="relative flex items-center gap-5 rounded-2xl overflow-hidden active:scale-[0.98] transition-all duration-300 group"
+                    className="relative flex items-center gap-5 rounded-2xl overflow-hidden active:scale-98 transition-all duration-300 group"
                     style={{
                       textDecoration: "none",
                       color: "inherit",

--- a/src/app/pages/profile.tsx
+++ b/src/app/pages/profile.tsx
@@ -282,7 +282,7 @@ function FavoriteStylesSection() {
           <div key={style.id} className="relative">
             <Link
               to={`/recipe/${style.id}?mode=canonical`}
-              className="block rounded-2xl overflow-hidden active:scale-[0.97] transition-transform group"
+              className="block rounded-2xl overflow-hidden active:scale-97 transition-transform group"
               style={{
                 background: "var(--container-card)",
                 border: "1px solid var(--container-border-ghost)",
@@ -400,7 +400,7 @@ function SavedRecipesSection() {
             >
               <Link
                 to={buildSavedRecipeUrl(r)}
-                className="flex items-center gap-3 flex-1 min-w-0 px-3.5 py-3 active:scale-[0.99] transition-transform"
+                className="flex items-center gap-3 flex-1 min-w-0 px-3.5 py-3 active:scale-99 transition-transform"
                 style={{ textDecoration: "none", color: "inherit" }}
               >
                 <span
@@ -487,7 +487,7 @@ function EquipmentCategory({
     >
       <motion.button
         onClick={onToggle}
-        className="w-full flex items-center gap-3 px-4 py-3.5 active:scale-[0.99] transition-transform"
+        className="w-full flex items-center gap-3 px-4 py-3.5 active:scale-99 transition-transform"
         style={{ textAlign: "left" as any, cursor: "pointer" }}
       >
         <span style={{ fontSize: "var(--font-size-2-5xl)", flexShrink: 0 }}>{emoji}</span>
@@ -682,7 +682,7 @@ function FtuOnboarding({ onComplete }: { onComplete: () => void }) {
                         setOvenType(preset.id);
                         setOvenTemp(preset.maxTemp);
                       }}
-                      className="flex items-center gap-4 p-4 rounded-2xl active:scale-[0.98]"
+                      className="flex items-center gap-4 p-4 rounded-2xl active:scale-98"
                       animate={{
                         backgroundColor: active ? "var(--surface-container)" : "var(--container-bg-low)",
                         borderColor: active ? "var(--primary)" : "var(--container-border)",
@@ -745,7 +745,7 @@ function FtuOnboarding({ onComplete }: { onComplete: () => void }) {
                     <motion.button
                       key={skill.level}
                       onClick={() => setSkillLevel(skill.level as SkillLevel)}
-                      className="flex items-center gap-4 p-4 rounded-2xl active:scale-[0.98]"
+                      className="flex items-center gap-4 p-4 rounded-2xl active:scale-98"
                       animate={{
                         backgroundColor: active ? "var(--surface-container)" : "var(--container-bg-low)",
                         borderColor: active ? "var(--primary)" : "var(--container-border)",
@@ -1523,7 +1523,7 @@ export function ProfilePage() {
                       return [preset.id, ...prev.filter((x) => x !== preset.id)];
                     });
                   }}
-                  className="flex items-center gap-3 p-3 sm:p-4 rounded-xl active:scale-[0.98]"
+                  className="flex items-center gap-3 p-3 sm:p-4 rounded-xl active:scale-98"
                   animate={{
                     backgroundColor: active
                       ? "var(--surface-container)"
@@ -1620,7 +1620,7 @@ export function ProfilePage() {
                 <motion.button
                   key={skill.level}
                   onClick={() => setSkillLevel(skill.level as SkillLevel)}
-                  className="flex flex-col items-start gap-1 p-3 sm:p-4 rounded-xl active:scale-[0.98]"
+                  className="flex flex-col items-start gap-1 p-3 sm:p-4 rounded-xl active:scale-98"
                   animate={{
                     backgroundColor: active
                       ? "var(--surface-container)"
@@ -1702,7 +1702,7 @@ export function ProfilePage() {
                     <motion.button
                       key={mixer.id}
                       onClick={() => toggleMixer(mixer.id)}
-                      className="flex items-center gap-3 px-3 py-2.5 rounded-lg active:scale-[0.98]"
+                      className="flex items-center gap-3 px-3 py-2.5 rounded-lg active:scale-98"
                       animate={{
                         backgroundColor: active ? "var(--surface-container)" : "transparent",
                         borderColor: active ? "var(--primary)" : "var(--container-border)",
@@ -1776,7 +1776,7 @@ export function ProfilePage() {
                     <motion.button
                       key={surface.id}
                       onClick={() => toggleSurface(surface.id)}
-                      className="flex items-center gap-3 px-3 py-2.5 rounded-lg active:scale-[0.98]"
+                      className="flex items-center gap-3 px-3 py-2.5 rounded-lg active:scale-98"
                       animate={{
                         backgroundColor: active ? "var(--surface-container)" : "transparent",
                         borderColor: active ? "var(--primary)" : "var(--container-border)",
@@ -2044,7 +2044,7 @@ export function ProfilePage() {
                         <button
                           key={`${result.lat}-${result.lon}-${i}`}
                           onClick={() => selectLocation(result)}
-                          className="w-full flex items-center gap-3 px-3.5 py-2.5 text-left active:scale-[0.99] transition-transform"
+                          className="w-full flex items-center gap-3 px-3.5 py-2.5 text-left active:scale-99 transition-transform"
                           style={{
                             borderBottom: i < locationResults.length - 1 ? "1px solid var(--container-border-subtle)" : "none",
                           }}
@@ -2233,7 +2233,7 @@ export function ProfilePage() {
                     key={option.id}
                     type="button"
                     onClick={() => setUnitSystem(option.id)}
-                    className="flex items-start gap-3 p-3 sm:p-4 rounded-xl text-left active:scale-[0.98]"
+                    className="flex items-start gap-3 p-3 sm:p-4 rounded-xl text-left active:scale-98"
                     initial={false}
                     animate={{
                       backgroundColor: active ? "var(--surface-container)" : "var(--container-bg-low)",
@@ -2281,7 +2281,7 @@ export function ProfilePage() {
           <button
             type="button"
             onClick={() => setPizzaNerd((value) => !value)}
-            className="w-full flex items-center gap-3 rounded-2xl px-4 py-3.5 text-left active:scale-[0.99] transition-transform"
+            className="w-full flex items-center gap-3 rounded-2xl px-4 py-3.5 text-left active:scale-99 transition-transform"
             style={{
               background: pizzaNerd
                 ? "color-mix(in srgb, var(--primary) 10%, var(--container-bg))"

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -239,11 +239,9 @@
   --space-12: 3rem; /* 48px */
   --space-16: 4rem; /* 64px */
   --space-20: 5rem; /* 80px */
-  --space-24: 6rem; /* 96px */
 
   /* ── Border Primitives ── */
   --border-width-thin: 1px;
-  --border-width-medium: 2px;
   --border-width-thick: 3px;
   --scrollbar-width-thin: thin;
 
@@ -269,25 +267,20 @@
   --background: var(--color-parchment-50);
   --foreground: var(--color-night-1000);
   --card: var(--color-parchment-0);
-  --card-foreground: var(--color-night-1000);
   --popover: var(--color-parchment-0);
-  --popover-foreground: var(--color-night-1000);
   --primary: var(--color-terracotta-500);
+  --ring: var(--color-terracotta-600);
   --primary-foreground: var(--color-white);
   --secondary: var(--color-mocha-500);
   --secondary-foreground: var(--color-white);
   --muted: var(--color-parchment-200);
   --muted-foreground: var(--color-mocha-700);
   --accent: var(--color-parchment-200);
-  --accent-foreground: var(--color-night-1000);
   --destructive: var(--color-red-500);
   --destructive-foreground: var(--color-white);
   --border: var(--color-parchment-600);
   --border-muted: var(--color-parchment-400);
-  --input: transparent;
-  --input-background: var(--color-parchment-200);
   --switch-background: var(--color-parchment-700);
-  --ring: var(--color-terracotta-600);
 
   /* ── Color · Accents (semantic, domain) ──
      Ruoli che prima erano rgba/primitive sparsi nei componenti:
@@ -301,17 +294,9 @@
   --severity-warning: var(--color-amber-500);
   --severity-info: var(--color-mocha-500);
 
-  /* ── Color · Chart ── */
-  --chart-1: var(--color-terracotta-500);
-  --chart-2: var(--color-amber-500);
-  --chart-3: var(--color-sage-600);
-  --chart-4: var(--color-mocha-500);
-  --chart-5: var(--color-sienna-400);
-
 
   /* ── Color · Surface Tones (M3 tonal system) ── */
   --surface: var(--color-parchment-50);
-  --surface-dim: var(--color-parchment-400);
   --surface-bright: var(--color-parchment-0);
   --surface-container-lowest: var(--color-parchment-0);
   --surface-container-low: var(--color-parchment-100);
@@ -365,7 +350,6 @@
   /* ── CTA (action) ── */
   --cta: var(--color-sage-600);
   --cta-foreground: var(--color-white);
-  --cta-hover: var(--color-sage-700);
 
   /* ── Gradients ── */
   --grad-ember: linear-gradient(
@@ -385,7 +369,6 @@
     var(--color-sage-600) 0%,
     var(--color-sage-500) 100%
   );
-  --grad-surface: none;
   --shadow-color: var(--color-black);
 
   /* ── Elevation / Shadows ── */
@@ -405,16 +388,11 @@
   --shadow-glow: 0 0 0 3px rgba(194, 74, 47, 0.14);
   --shadow-cta: 0 4px 14px rgba(45, 106, 79, 0.2);
 
-  --elevation-0: none;
-  --elevation-1: var(--shadow-sm);
-  --elevation-2: var(--shadow-md);
-  --elevation-3: var(--shadow-lg);
   --elevation-glow: var(--shadow-glow);
   --elevation-glow-lg: 0 0 0 4px rgba(194, 74, 47, 0.18);
   --elevation-cta: var(--shadow-cta);
 
   --border-w: var(--border-width-thin);
-  --border-w-thick: var(--border-width-thin);
 
   /* ═══════════════════════════════════════════════════════════════════
      TIER 2.5 — DATA VISUALIZATION & FORGE  (semantic, domain-specific)
@@ -461,26 +439,20 @@
   --text-warning: var(--tertiary);
   --text-error: var(--destructive);
   --text-on-accent: var(--primary-foreground);
-  --text-on-cta: var(--cta-foreground);
-  --text-on-bg: var(--background);
 
   /* ── B. Icon Color Roles ── */
   --icon-default: var(--foreground);
   --icon-muted: var(--muted-foreground);
-  --icon-subtle: var(--on-surface-variant);
   --icon-accent: var(--primary);
   --icon-success: var(--cta);
   --icon-warning: var(--tertiary);
   --icon-error: var(--destructive);
-  --icon-on-accent: var(--primary-foreground);
 
   /* ── C. Container / Surface ── */
   --container-bg: var(--surface-container);
   --container-bg-low: var(--surface-container-low);
   --container-bg-high: var(--surface-container-high);
-  --container-bg-lowest: var(--surface-container-lowest);
   --container-border: var(--outline-variant);
-  --container-border-strong: var(--outline);
   --container-border-subtle: var(--border-muted);
   --container-card: var(--card);
   --container-divider: var(--outline-variant);
@@ -521,7 +493,6 @@
   --segmented-text-active: var(--foreground);
   --segmented-text-active-brand: var(--primary-foreground);
   --segmented-border: var(--outline-variant);
-  --segmented-border-active: var(--primary);
   --segmented-shadow-active: var(--shadow-sm);
   --segmented-font-size: var(--font-size-base);
   --segmented-font-size-sm: var(--font-size-sm);
@@ -545,66 +516,16 @@
   --btn-secondary-text: var(--foreground);
   --btn-secondary-border: var(--outline-variant);
   --btn-secondary-weight: var(--weight-semibold);
-  --btn-ghost-bg: var(--foreground);
-  --btn-ghost-text: var(--background);
-  --btn-ghost-weight: var(--weight-semibold);
-
-  /* ── G. Step Header ── */
-  --step-num-color: var(--primary);
-  --step-title-color: var(--foreground);
-  --step-line-color: var(--primary);
-  --step-subtitle-opacity: 0.65;
-
-  /* ── H. Stepper / ProgressPill ── */
-  --stepper-dot-active: var(--primary);
-  --stepper-dot-past: var(--outline);
-  --stepper-dot-future: var(--outline-variant);
-  --stepper-pill-bg: color-mix(
-    in srgb,
-    var(--surface-container) 85%,
-    transparent
-  );
-  --stepper-pill-border: var(--outline-variant);
-  --stepper-label-color: var(--primary);
-  --stepper-label-bg: color-mix(
-    in srgb,
-    var(--primary) 10%,
-    transparent
-  );
-
-  /* ── I. Tip / Coachmark ── */
-  --tip-bg: color-mix(
-    in srgb,
-    var(--surface-container) 88%,
-    transparent
-  );
-  --tip-bg-emphasis: color-mix(
-    in srgb,
-    var(--surface-container) 94%,
-    transparent
-  );
-  --tip-border: var(--outline-variant);
-  --tip-border-emphasis: color-mix(
-    in srgb,
-    var(--primary) 18%,
-    var(--outline-variant)
-  );
-  --tip-text: var(--muted-foreground);
-  --tip-icon: var(--tertiary);
-  --tip-bg-warm: var(--tertiary-container);
 
   /* ── I2. User Needs specifics ── */
   --needs-oven-bg: var(--surface-container);
   --needs-oven-border: var(--outline-variant);
-  --needs-oven-bg-low: var(--surface-container-low);
   --needs-pantry-accent: var(--tertiary);
   --needs-pantry-border-active: color-mix(
     in srgb,
     var(--tertiary) 40%,
     var(--outline-variant)
   );
-  --needs-yeast-bg-active: var(--cta);
-  --needs-yeast-text-active: var(--cta-foreground);
 
   /* ── J. Popover (InfoTip) ── */
   --popover-surface: var(--surface-container-lowest);
@@ -619,36 +540,8 @@
   --popover-trigger-active: var(--primary);
   --popover-trigger-idle: var(--muted-foreground);
 
-  /* ── K. Inline Tip ── */
-  --inline-tip-bg: var(--tertiary-container);
-  --inline-tip-border: var(--outline-variant);
-  --inline-tip-icon: var(--tertiary);
-  --inline-tip-text: var(--on-surface-variant);
-
   /* ── L. Score Dashboard ── */
   --score-accent: var(--primary);
-  --score-secondary: var(--tertiary);
-  --score-tertiary: var(--cta);
-  --score-track: var(--outline-variant);
-  --score-grid: var(--outline-variant);
-  --score-value: var(--foreground);
-  --score-label: var(--muted-foreground);
-  --score-bg: var(--surface-container);
-  --score-page: var(--background);
-  --score-card: var(--card);
-  --score-border: var(--outline-variant);
-  --score-border-strong: var(--outline);
-  --score-divider: var(--border);
-  --score-nerd-bg: color-mix(
-    in srgb,
-    var(--primary) 12%,
-    var(--surface-container)
-  );
-  --score-nerd-border: color-mix(
-    in srgb,
-    var(--primary) 25%,
-    var(--outline-variant)
-  );
 
   /* ── L2. Score Axes (RadarChart + devtools) ── */
   --axis-authenticity: var(--warm-sienna);
@@ -657,12 +550,6 @@
   --axis-sustainability: var(--warm-sage);
   --axis-experimentation: var(--secondary);
 
-  /* ── M. Stat Strip ── */
-  --stat-hydration: var(--primary);
-  --stat-oven: var(--tertiary);
-  --stat-cook: var(--cta);
-  --stat-ferment: var(--tertiary);
-
   /* ── N. Recipe Output ── */
   --recipe-bg: var(--surface-container);
   --recipe-border: var(--outline-variant);
@@ -670,7 +557,6 @@
   --recipe-divider-subtle: var(--border-muted);
   --recipe-highlight: var(--primary);
   --recipe-success: var(--cta);
-  --recipe-accent: var(--tertiary);
   --recipe-node-first-bg: var(--primary);
   --recipe-node-last-bg: var(--cta);
   --recipe-node-mid-bg: var(--surface-container);
@@ -726,51 +612,6 @@
     var(--forge-abyss) 100%
   );
 
-  /* ── Q. Time-slot chips ── */
-  --timeslot-tonight-bg: var(--time-tonight);
-  --timeslot-tonight-text: color-mix(
-    in srgb,
-    var(--time-tonight-soft) 30%,
-    white
-  );
-  --timeslot-lunch-bg: var(--time-lunch);
-  --timeslot-lunch-text: color-mix(
-    in srgb,
-    var(--time-lunch-soft) 20%,
-    white
-  );
-  --timeslot-dinner-bg: var(--time-dinner);
-  --timeslot-dinner-text: color-mix(
-    in srgb,
-    var(--time-dinner-soft) 25%,
-    white
-  );
-  --timeslot-dayafter-bg: var(--time-dayafter);
-  --timeslot-dayafter-text: color-mix(
-    in srgb,
-    var(--time-dayafter-soft) 25%,
-    white
-  );
-  --timeslot-weekend-bg: var(--time-weekend);
-  --timeslot-weekend-text: color-mix(
-    in srgb,
-    var(--time-weekend-soft) 25%,
-    white
-  );
-
-  /* ── R. Header / Glassmorphism ── */
-  --header-bg: color-mix(
-    in srgb,
-    var(--background) 88%,
-    transparent
-  );
-  --header-bg-dense: color-mix(
-    in srgb,
-    var(--background) 92%,
-    transparent
-  );
-  --header-border: var(--border-muted);
-
   /* ── S. Brand / Glow (FireGlow, Logo) ── */
   --glow-primary: var(--primary);
   --glow-secondary: var(--tertiary);
@@ -788,7 +629,6 @@
   --recipe-hero-card-bg: color-mix(in srgb, var(--container-page) 88%, transparent);
   --recipe-hero-card-shadow: var(--shadow-lg);
   --recipe-hero-badge-bg: color-mix(in srgb, var(--text-accent) 8%, transparent);
-  --recipe-hero-badge-text: var(--text-accent);
 
   --hero-glow-warm: radial-gradient(
     ellipse at 48% 52%,
@@ -874,7 +714,6 @@
   --overlay-shadow-text:
     0 2px 8px rgba(0, 0, 0, 0.6), 0 0 24px rgba(0, 0, 0, 0.25);
   --overlay-shadow-text-sm: 0 1px 4px rgba(0, 0, 0, 0.5);
-  --overlay-shadow-text-lg: 0 2px 20px rgba(0, 0, 0, 0.6);
   --overlay-scrim: linear-gradient(
     180deg,
     rgba(0, 0, 0, 0) 0%,
@@ -890,10 +729,6 @@
   --score-ring-track-stroke: rgba(255, 255, 255, 0.08);
   --score-ring-text: var(--color-white);
 
-  /* ── L (ext). Score Dashboard modal ── */
-  --score-modal-backdrop: rgba(0, 0, 0, 0.45);
-  --score-modal-shadow: 0 -8px 40px rgba(0, 0, 0, 0.18);
-
   /* ── N2. Style Card (recommended-styles) ── */
   --style-card-shadow:
     0 2px 8px -2px rgba(0, 0, 0, 0.08),
@@ -905,19 +740,6 @@
   /* ── E (ext). Button shadows ── */
   --cta-btn-shadow-deep:
     var(--cta-btn-shadow), 0 8px 30px rgba(0, 0, 0, 0.1);
-  --btn-secondary-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  --btn-ghost-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
-
-  /* ── S (ext). Logo badge ── */
-  --logo-badge-shadow: 0 2px 8px
-    color-mix(in srgb, var(--logo-glow) 25%, transparent);
-
-  /* ── T (ext). Hero result scrim — subtle vignette only (title moved outside photo) ── */
-  --hero-result-scrim: radial-gradient(
-    ellipse at 50% 40%,
-    rgba(0, 0, 0, 0) 40%,
-    rgba(0, 0, 0, 0.18) 100%
-  );
 
   /* ── X. Card Photo Scrims (bottom-up gradient for text legibility) ── */
   --card-scrim-light: linear-gradient(
@@ -933,11 +755,6 @@
   --card-scrim-heavy: linear-gradient(
     to top,
     rgba(0, 0, 0, 0.65) 0%,
-    rgba(0, 0, 0, 0) 100%
-  );
-  --card-scrim-hero: linear-gradient(
-    to top,
-    rgba(0, 0, 0, 0.7) 0%,
     rgba(0, 0, 0, 0) 100%
   );
   --card-scrim-subtle: rgba(0, 0, 0, 0.08);
@@ -988,6 +805,24 @@
   --dialog-scrim-strong: var(--overlay-backdrop);
   --dialog-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
   --dialog-shadow-compact: 0 24px 48px rgba(0, 0, 0, 0.18);
+
+  /* ── AE2. Glass (backdrop-filter) — scala unica per scrim e superfici ── */
+  --backdrop-glass-soft: blur(10px); /* scrim leggero (panel solidi) */
+  --backdrop-glass: blur(20px) saturate(1.4); /* scrim dietro sheet glass */
+  --backdrop-glass-strong: blur(24px) saturate(1.6); /* superficie sheet glass */
+  --backdrop-glass-max: blur(28px) saturate(1.7); /* superficie glass densa (picker) */
+  --sheet-glass-bg: color-mix(
+    in srgb,
+    var(--container-page) 94%,
+    transparent
+  );
+
+  /* ── AF. Z-index scale (livelli sopra z-50 di Tailwind) ──
+     Consumo: className="z-(--z-widget)" (sintassi var Tailwind 4).
+     Sotto i 50 si usa la scala nativa z-10..z-50. */
+  --z-widget: 70; /* floating widget persistenti (active-cook) */
+  --z-modal: 80; /* sheet/modali sopra ogni chrome di pagina */
+  --z-skiplink: 9999; /* skip-link a11y: sempre sopra tutto */
 }
 
 .dark {
@@ -995,17 +830,15 @@
   --background: var(--color-night-900);
   --foreground: var(--color-night-0);
   --card: var(--color-night-700);
-  --card-foreground: var(--color-night-0);
   --popover: var(--color-night-700);
-  --popover-foreground: var(--color-night-0);
   --primary: var(--color-terracotta-300);
+  --ring: var(--color-terracotta-300);
   --primary-foreground: var(--color-terracotta-900);
   --secondary: var(--color-mocha-400);
   --secondary-foreground: var(--color-night-1000);
   --muted: var(--color-night-500);
   --muted-foreground: var(--color-parchment-900);
   --accent: var(--color-night-500);
-  --accent-foreground: var(--color-night-0);
   --destructive: var(--color-red-400);
   --destructive-foreground: var(--color-red-800);
   --border: var(--color-night-200);
@@ -1022,18 +855,9 @@
   --tab-indicator-bg: linear-gradient(145deg, color-mix(in srgb, var(--container-page) 86%, transparent), color-mix(in srgb, var(--primary) 18%, transparent));
   --tab-indicator-border: 1px solid color-mix(in srgb, var(--primary) 18%, transparent);
   --tab-indicator-shadow: 0 8px 18px color-mix(in srgb, var(--primary) 12%, transparent), inset 0 1px 0 color-mix(in srgb, var(--overlay-text) 22%, transparent);
-  --input: var(--color-night-500);
-  --input-background: var(--color-night-500);
   --switch-background: var(--color-mocha-800);
-  --ring: var(--color-terracotta-300);
-  --chart-1: var(--color-terracotta-300);
-  --chart-2: var(--color-amber-300);
-  --chart-3: var(--color-sage-300);
-  --chart-4: var(--color-parchment-900);
-  --chart-5: var(--color-terracotta-300);
 
   --surface: var(--color-night-900);
-  --surface-dim: var(--color-night-900);
   --surface-bright: var(--color-night-250);
   --surface-container-lowest: var(--color-night-950);
   --surface-container-low: var(--color-night-800);
@@ -1058,13 +882,6 @@
   --inverse-surface: var(--color-parchment-100);
   --inverse-on-surface: var(--color-night-800);
 
-  /* ── T (ext). Hero result scrim — dark mode: mild vignette + bottom tonal blend ── */
-  --hero-result-scrim: radial-gradient(
-    ellipse at 50% 40%,
-    rgba(0, 0, 0, 0) 40%,
-    rgba(0, 0, 0, 0.3) 100%
-  );
-
   --warm-terracotta: var(--color-terracotta-300);
   --warm-sienna: var(--color-terracotta-300);
   --warm-oak: var(--color-amber-300);
@@ -1078,7 +895,6 @@
 
   --cta: var(--color-sage-300);
   --cta-foreground: var(--color-night-1000);
-  --cta-hover: var(--color-sage-700);
   --cta-shadow: 0 4px 14px rgba(114, 200, 166, 0.18);
 
   /* Time-of-day palette (dark — vivid) */
@@ -1108,7 +924,6 @@
     var(--color-sage-300) 0%,
     var(--color-sage-350) 100%
   );
-  --grad-surface: none;
 
   --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.25);
   --shadow-sm:
@@ -1124,16 +939,11 @@
   --shadow-glow: 0 0 0 3px rgba(244, 146, 106, 0.25);
   --shadow-cta: 0 4px 14px rgba(114, 200, 166, 0.18);
 
-  --elevation-0: none;
-  --elevation-1: var(--shadow-sm);
-  --elevation-2: var(--shadow-md);
-  --elevation-3: var(--shadow-lg);
   --elevation-glow: var(--shadow-glow);
   --elevation-glow-lg: 0 0 0 4px rgba(244, 146, 106, 0.3);
   --elevation-cta: var(--shadow-cta);
 
   --border-w: var(--border-width-thin);
-  --border-w-thick: var(--border-width-thin);
 
   /* ── Tier 2.5 — Data-viz & Forge (dark adaptations) ── */
   --data-water: var(--color-water-300);
@@ -1152,8 +962,6 @@
 
   /* ── Tier 3 dark overrides for shadows/buttons ── */
   --overlay-backdrop: rgba(0, 0, 0, 0.6);
-  --score-modal-backdrop: rgba(0, 0, 0, 0.6);
-  --score-modal-shadow: 0 -8px 40px rgba(0, 0, 0, 0.35);
   --style-card-shadow:
     0 2px 8px -2px rgba(0, 0, 0, 0.25),
     0 1px 3px rgba(0, 0, 0, 0.18);
@@ -1162,10 +970,6 @@
   --style-card-badge-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
   --cta-btn-shadow-deep:
     var(--elevation-cta), 0 8px 30px rgba(0, 0, 0, 0.25);
-  --btn-secondary-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
-  --btn-ghost-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
-  --logo-badge-shadow: 0 2px 8px
-    color-mix(in srgb, var(--logo-glow) 30%, transparent);
 
   /* ── Tier 3 dark overrides (new groups X–AD) ── */
   --sheet-backdrop: rgba(0, 0, 0, 0.5);
@@ -1178,6 +982,14 @@
 }
 
 @theme inline {
+  /* Palette default Tailwind DISATTIVATA: le utility colore esistono solo per
+     i token semantici mappati qui sotto. `bg-red-500` & co. non compilano —
+     l'enforcement "solo token DS" avviene a build-time, non solo nel linter. */
+  --color-*: initial;
+  /* Bianco/nero riammessi: scrim e testo su fotografia (bg-black/40, text-white). */
+  --color-white: #ffffff;
+  --color-black: #000000;
+
   --font-sans: "DM Sans", sans-serif;
   --font-serif: "Playfair Display", serif;
   --font-mono: "DM Mono", monospace;
@@ -1186,32 +998,13 @@
      Kept as alias of --font-sans so it can diverge later without touching call sites. */
   --font-body: var(--font-sans);
 
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
-  --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--secondary);
-  --color-secondary-foreground: var(--secondary-foreground);
   --color-muted: var(--muted);
-  --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-destructive: var(--destructive);
-  --color-destructive-foreground: var(--destructive-foreground);
-  --color-border: var(--border);
-  --color-input: var(--input);
-  --color-input-background: var(--input-background);
-  --color-switch-background: var(--switch-background);
-  --color-ring: var(--ring);
-  --color-chart-1: var(--chart-1);
-  --color-chart-2: var(--chart-2);
-  --color-chart-3: var(--chart-3);
-  --color-chart-4: var(--chart-4);
-  --color-chart-5: var(--chart-5);
+  /* Micro-etichette (badge, pill di stato): sotto text-xs, sulla scala tipografica. */
+  --text-2xs: 0.625rem;
+  --text-2xs--line-height: 1.4;
   --radius-xs: var(--radius-xs);
   --radius-sm: var(--radius-sm);
   --radius-md: var(--radius-md);
@@ -1238,7 +1031,8 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    border-color: var(--border);
+    outline-color: color-mix(in srgb, var(--ring) 50%, transparent);
   }
 
   html {
@@ -1248,7 +1042,8 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    background-color: var(--background);
+    color: var(--foreground);
     overflow-x: hidden;
     max-width: 100%;
     font-family: var(--font-sans);
@@ -1473,15 +1268,6 @@
       "tnum" 1;
   }
 
-  /** Micro inline code/data annotation */
-  .type-code-xs {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs); /* 9px */
-    letter-spacing: var(--tracking-spread);
-    font-feature-settings:
-      "kern" 1,
-      "tnum" 1;
-  }
 
   /** Raw data values: W320, 68%, temperatures — tabular nums, DM Sans */
   .type-data-base {
@@ -1651,17 +1437,6 @@
       "calt" 1;
   }
 
-  /** Editorial quote: Playfair italic for citations */
-  .type-editorial-quote {
-    font-family: var(--font-serif);
-    font-style: italic;
-    font-size: var(--font-size-2xl); /* 16px */
-    line-height: var(--leading-reading); /* 1.6 */
-    font-feature-settings:
-      "kern" 1,
-      "liga" 1,
-      "calt" 1;
-  }
 
   /* ── Typography · DM Sans family ──────────────────────────── */
 
@@ -1722,14 +1497,6 @@
     text-transform: uppercase;
   }
 
-  /** Label SM: compact uppercase UI labels */
-  .type-label-sm {
-    font-family: var(--font-sans);
-    font-size: var(--font-size-base); /* 11px */
-    font-weight: var(--weight-semibold);
-    letter-spacing: var(--tracking-widest);
-    text-transform: uppercase;
-  }
 
   /** Label XS: dense uppercase UI labels */
   .type-label-xs {


### PR DESCRIPTION
## Obiettivo

Audit pulizia/ottimizzazione con allineamento **bidirezionale** al design system: il codice consuma solo token, e il design system non tiene token che nessuno consuma. Più modularità sui pattern duplicati.

## Direzione DS → codice (debito morto rimosso)

- **119 token eliminati** da `theme.css` (mai consumati da nulla, nemmeno dallo showcase): gruppi interi `--score-*`, `--tip-*`, `--timeslot-*`, `--stepper-*`, `--step-*`, `--elevation-0..3`, `--btn-ghost-*`, ombre/scrim orfani, e metà delle mappature shadcn del blocco `@theme` (`--color-card`, `--color-popover`, `--color-chart-*`, …). Analisi iterata a fixpoint (2 passate) tenendo conto delle utility Tailwind derivate dai token `@theme`.
- **3 composite typography morte** rimosse (`.type-code-xs`, `.type-editorial-quote`, `.type-label-sm`).
- Ripristinato `--ring` (era consumato dal focus outline globale) e convertiti i due `@apply` della base layer (`border-border`, `bg-background`) in CSS puro sui token — non dipendono più dalle mappature utility.

## Direzione codice → DS (valori raw → token)

- **Palette default Tailwind disattivata** (`--color-*: initial` in `@theme`): `bg-red-500` & co. non esistono più a build; riammessi solo `white`/`black` (scrim e testo su foto). L'enforcement "solo token DS" ora è a build-time, non solo nel linter.
- Nuovo token `--text-2xs` (micro-etichette) al posto di 6 `text-[10px]`.
- **Scala z-index tokenizzata**: `--z-widget` (70), `--z-modal` (80), `--z-skiplink` (9999), consumati con la sintassi var di Tailwind 4 `z-(--z-*)`. Rimossi tutti gli `z-[N]` arbitrari.
- **285 `scale-[0.98]`-e-simili** convertiti ai valori bare di Tailwind 4 (`scale-98`, `active:scale-95`…): stesso CSS, zero parentesi arbitrarie. Due valori off-scale (0.995, 0.985) arrotondati di mezzo punto.
- **Token glass**: `--backdrop-glass-soft/-/strong/max` + `--sheet-glass-bg` al posto dei `blur(N) saturate(M)` copiati in 6 file. La superficie sheet è normalizzata a un'unica densità (92%→94% sul setup panel, impercettibile).
- `fontWeight: 600/800` numerici → `var(--weight-semibold/bold)`.

## Modularità

- **Nuovo `ds/ModalSheet` (T4)**: guscio unico per i modali responsive (sheet dal basso su mobile, card centrata da `sm`), con varianti ortogonali `scrim`/`surface`/`entry`/`size`/`height` e gestione Escape integrata. Migrati i **5 modali hand-rolled** di recipe: `recipe-output-bits` (glossario W), `interpretation-narrative-card`, `recipe-setup-panel`, `condiment-choice-strip`, `recipe-learning-panel` (~150 righe di boilerplate scrim/motion eliminate; il learning panel passa da `rounded-3xl` a `rounded-4xl` per coerenza di famiglia).

## Enforcement permanente (`check:tokens`)

Nuove regole bloccanti in `scripts/check-design-tokens.mjs`:
- `tw-raw-palette` — classi palette default (che ora fallirebbero in silenzio a build)
- `arbitrary-font-size` / `arbitrary-z` / `arbitrary-scale` — niente più `text-[Npx]`, `z-[N]`, `scale-[x]`
- **`dead-token` / `dead-composite`** — il check bidirezionale: token o composite definiti in `theme.css` ma mai consumati (né `var()`, né utility `@theme` derivata) = errore, con allowlist `STAGED_TOKENS` per i rollout graduali.

Le regole nuove sono state auto-testate iniettando violazioni finte (tutte scattano).

## Verifica

- `npm run verify` ✓ (tsc + check:tokens + 22 test vitest)
- `npm run build` ✓; ispezionato il CSS emesso: palette default assente, `text-white`/`bg-black/40`/`text-2xs`/`z-(--z-*)`/`scale-98` compilano
- Smoke test nel browser sul flusso reale: home → scelta stile → generazione ricetta → modale "Personalizza parametri" (ModalSheet full) → chiusura con Escape → modale glossario "W" (ModalSheet sm). Rendering identico al design, zero errori console.

## Follow-up suggeriti (fuori scope)

- Split dei monoliti `profile.tsx` (2419 righe, 150 stili inline) e `home.tsx` (2043)
- Dimensioni icon-button inline (`width: 36/38/40`) → `IconButton` ds
- Blur singoli non a scala (4/6/12/18px) e `saturate(1.8)` di recipe-output

🤖 Generated with [Claude Code](https://claude.com/claude-code)