### PR TITLE
fix(ds): applica i finding della code review post-#28

### DIFF
--- a/scripts/check-design-tokens.mjs
+++ b/scripts/check-design-tokens.mjs
@@ -12,7 +12,7 @@
  *
  * Uso: `npm run check:tokens`  (o `npm run verify` per tsc + guard).
  */
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const ROOT = "src/app";
@@ -104,7 +104,7 @@ const RULES = [
     desc: "Classe palette Tailwind di default (bg-red-500…) → token semantico. La palette è disattivata in @theme: la classe NON compila e fallisce in silenzio.",
     test: (l) =>
       l.match(
-        /\b(?:bg|text|border|ring|fill|stroke|from|to|via|shadow|outline|decoration|accent|caret|divide)-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\d+(?:\/\d+)?\b/g,
+        /\b(?:bg|text|placeholder|border|divide|ring-offset|inset-ring|ring|fill|stroke|from|to|via|shadow|outline|decoration|accent|caret)(?:-(?:[trblxyse]|ss|se|es|ee))?-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)-\d+(?:\/\d+)?\b/g,
       ),
   },
   {
@@ -217,6 +217,9 @@ const STAGED_TOKENS = new Set([
   /* es. "--nuovo-token", // in rollout fino a <data/PR> */
 ]);
 
+/* A differenza del guard in avanti, qui lo showcase È incluso: le sue pagine
+ * renderizzano davvero i token (swatch, demo glass/dynamics), quindi contano
+ * come consumo — escluderle romperebbe /design-system. */
 function walkAll(dir, acc = []) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
@@ -226,14 +229,23 @@ function walkAll(dir, acc = []) {
   return acc;
 }
 
-try {
+/* Consumo "vivo" = occorrenza dell'identificatore con confini: `--primary`
+ * dentro `var(--primary-foreground)` NON tiene vivo `--primary`. */
+const boundaryRe = (id) => new RegExp(`(?<![a-z0-9-])${id}(?![a-z0-9-])`);
+
+/* Guard esplicito (niente try/catch: un errore qui deve fallire il check,
+ * non disattivarlo in silenzio). */
+if (existsSync(CSS_FILE)) {
   const css = readFileSync(CSS_FILE, "utf8");
   const cssLines = css.split("\n");
   const lineOf = (name, matcher) => {
     const idx = cssLines.findIndex((l) => matcher.test(l));
     return idx === -1 ? 1 : idx + 1;
   };
-  const themeBlock = css.match(/@theme inline \{[\s\S]*?\n\}/)?.[0] ?? "";
+  /* Le definizioni/consumi si cercano nel CSS senza commenti: un blocco
+   * commentato non definisce né tiene vivo nulla. */
+  const cssClean = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const themeBlock = cssClean.match(/@theme inline \{[\s\S]*?\n\}/)?.[0] ?? "";
   const themeTokens = new Set(
     [...themeBlock.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm)].map((m) => m[1]),
   );
@@ -249,14 +261,14 @@ try {
     .join("\n");
 
   const tokenDefs = [
-    ...new Set([...css.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm)].map((m) => m[1])),
+    ...new Set([...cssClean.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm)].map((m) => m[1])),
   ];
   for (const t of tokenDefs) {
     if (STAGED_TOKENS.has(t)) continue;
     const name = t.slice(2);
     const varRe = new RegExp(`var\\(${t}[\\),]`);
-    if (varRe.test(allSources) || varRe.test(css)) continue;
-    if (allSources.includes(t)) continue; // riferimento letterale (stringa JS)
+    if (varRe.test(cssClean)) continue; // consumato dentro theme.css
+    if (boundaryRe(t).test(allSources)) continue; // var(--x) o stringa letterale
     if (themeTokens.has(t)) {
       /* Token @theme: vivo anche se consumato via utility Tailwind derivata.
        * `--text-2xs--line-height` è un modificatore del token base: segue
@@ -265,7 +277,7 @@ try {
       let utilRe = null;
       if (name.startsWith("color-")) {
         utilRe = new RegExp(
-          `\\b(?:bg|text|border|ring|fill|stroke|divide|outline|accent|caret|decoration|from|to|via|shadow|placeholder|inset-ring)-${name.slice(6)}(?![a-z-])`,
+          `\\b(?:bg|text|placeholder|border|divide|ring-offset|inset-ring|ring|fill|stroke|outline|accent|caret|decoration|from|to|via|shadow)(?:-(?:[trblxyse]|ss|se|es|ee))?-${name.slice(6)}(?![a-z-])`,
         );
       } else if (name.startsWith("radius-")) {
         utilRe = new RegExp(`\\brounded(?:-[trbleyxs]{1,2})?-${name.slice(7)}(?![a-z-])`);
@@ -285,14 +297,12 @@ try {
     });
   }
 
-  const compBlock = css
-    .slice(css.indexOf("@layer components"))
-    .replace(/\/\*[\s\S]*?\*\//g, "");
+  const compBlock = cssClean.slice(cssClean.indexOf("@layer components"));
   const compClasses = [
     ...new Set([...compBlock.matchAll(/^\s*\.([a-z][a-z0-9-]+)/gm)].map((m) => m[1])),
   ];
   for (const c of compClasses) {
-    if (!allSources.includes(c)) {
+    if (!boundaryRe(c).test(allSources)) {
       violations.push({
         file: CSS_FILE,
         line: lineOf(c, new RegExp(`^\\s*\\.${c}\\b`)),
@@ -302,8 +312,6 @@ try {
       });
     }
   }
-} catch {
-  /* theme.css assente: ignora */
 }
 
 const errors = violations.filter((v) => v.severity !== "warn");

--- a/src/app/components/ds/ModalSheet.tsx
+++ b/src/app/components/ds/ModalSheet.tsx
@@ -5,6 +5,7 @@
  * card centrata da `sm` in su. Scrim, superficie, animazione e layering
  * consumano SOLO token (`--z-modal`, `--backdrop-glass-*`, `--sheet-glass-bg`,
  * `--dialog-*`, `--container-*`). Chiude su click-scrim e su Escape.
+ * Monta in portal su document.body: i call site non devono portalare.
  *
  * Varianti ortogonali:
  *  - `scrim`    glass (blur forte) · soft (blur leggero) · plain (solo tinta)
@@ -16,6 +17,7 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect } from "react";
 import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 export interface ModalSheetProps {
   open: boolean;
@@ -120,7 +122,10 @@ export function ModalSheet({
     ? "rounded-t-4xl sm:rounded-4xl border-0 sm:border"
     : "rounded-4xl border";
 
-  return (
+  /* Portal su body: `fixed inset-0` si rompe sotto antenati con transform
+   * (es. pannelli motion draggabili), quindi il portal è responsabilità del
+   * guscio, non dei call site. */
+  const sheet = (
     <AnimatePresence>
       {open && (
         <motion.div
@@ -154,4 +159,7 @@ export function ModalSheet({
       )}
     </AnimatePresence>
   );
+
+  if (typeof document === "undefined") return sheet;
+  return createPortal(sheet, document.body);
 }

--- a/src/app/features/recipe/condiment-choice-strip.tsx
+++ b/src/app/features/recipe/condiment-choice-strip.tsx
@@ -1,9 +1,7 @@
 /* ═══ CONDIMENT CHOICE STRIP — selettore condimenti (estratto lug 2026) ═══ */
 
 import { Search, Utensils, X } from "lucide-react";
-import { motion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import toppingPlaceholder from "../../../assets/toppings/_placeholder.svg";
 import { useCms } from "../cms/cms-context";
 import { IconButton, ModalSheet } from "../../components/ds/index";
@@ -319,8 +317,7 @@ export function CondimentChoiceStrip({
           aria-hidden="true"
         />
       )}
-      {!isTimeline && typeof document !== "undefined"
-          ? createPortal(
+      {!isTimeline && (
               <ModalSheet
                 open={pickerOpen}
                 onClose={() => setPickerOpen(false)}
@@ -329,9 +326,9 @@ export function CondimentChoiceStrip({
                 scrim="plain"
                 surface="glass-dense"
                 entry="pop"
-                panelClassName="overflow-hidden"
+                panelClassName="flex flex-col overflow-hidden"
               >
-                  <div className="flex items-start gap-3 px-4 pb-3 pt-4 sm:px-5 sm:pt-5">
+                  <div className="flex flex-shrink-0 items-start gap-3 px-4 pb-3 pt-4 sm:px-5 sm:pt-5">
                     <div className="min-w-0 flex-1">
                       <div
                         className="type-data-sm"
@@ -381,9 +378,9 @@ export function CondimentChoiceStrip({
                     </IconButton>
                   </div>
 
-                  <div className="px-4 pb-4 sm:px-5 sm:pb-5">
+                  <div className="flex min-h-0 flex-col px-4 pb-4 sm:px-5 sm:pb-5">
                     <div
-                      className="flex items-center gap-2 rounded-2xl px-3"
+                      className="flex flex-shrink-0 items-center gap-2 rounded-2xl px-3"
                       style={{
                         minHeight: 46,
                         background: "var(--container-bg-low)",
@@ -417,7 +414,7 @@ export function CondimentChoiceStrip({
                       )}
                     </div>
 
-                    <div className="mt-3 flex gap-2 overflow-x-auto pb-1 hide-scrollbar">
+                    <div className="mt-3 flex flex-shrink-0 gap-2 overflow-x-auto pb-1 hide-scrollbar">
                       <button
                         type="button"
                         onClick={() => setActiveFlavor("all")}
@@ -455,7 +452,7 @@ export function CondimentChoiceStrip({
                       ))}
                     </div>
 
-                    <div className="mt-3 max-h-[48vh] overflow-y-auto pr-1 sm:max-h-[440px]">
+                    <div className="mt-3 min-h-0 max-h-[48vh] overflow-y-auto pr-1 sm:max-h-[440px]">
                       <div className="grid gap-2 sm:grid-cols-2">
                         {filteredPickerChoices.length > 0 ? (
                           filteredPickerChoices.map(({ recipe }) => {
@@ -526,11 +523,8 @@ export function CondimentChoiceStrip({
                       </div>
                     </div>
                   </div>
-              </ModalSheet>,
-              document.body,
-              "topping-choice-sheet",
-            )
-          : null}
+              </ModalSheet>
+      )}
     </div>
   );
 }

--- a/src/app/features/recipe/feedback-analysis.tsx
+++ b/src/app/features/recipe/feedback-analysis.tsx
@@ -448,7 +448,7 @@ function AdversarialRow({ finding }: { finding: AdversarialFinding }) {
           style={{
             fontSize: "var(--font-size-xs)",
             fontFamily: "var(--font-mono)",
-            fontWeight: "var(--weight-bold)" as any,
+            fontWeight: "var(--weight-extrabold)" as any,
             letterSpacing: "0.08em",
             background: severityColors[finding.severity],
             color: "var(--overlay-text)",

--- a/src/app/features/recipe/recipe-learning-panel.tsx
+++ b/src/app/features/recipe/recipe-learning-panel.tsx
@@ -20,12 +20,12 @@ export function RecipeLearningPanel({
     <ModalSheet
       open={open}
       onClose={onClose}
-      ariaLabel={`Approfondimenti su ${style.name}`}
+      ariaLabelledby="learning-panel-title"
       size="lg"
       scrim="soft"
       surface="solid"
       entry="pop"
-      panelClassName="overflow-hidden"
+      panelClassName="overflow-y-auto overscroll-contain"
     >
             <div
               className="flex items-start gap-4 px-5 py-5 sm:px-6"
@@ -46,6 +46,7 @@ export function RecipeLearningPanel({
                   <span>Approfondimento</span>
                 </p>
                 <h2
+                  id="learning-panel-title"
                   className="font-serif mt-1"
                   style={{
                     fontSize: "clamp(var(--font-size-4xl), 6vw, var(--font-size-6xl))",

--- a/src/app/features/recipe/recipe-output-bits.tsx
+++ b/src/app/features/recipe/recipe-output-bits.tsx
@@ -3,7 +3,6 @@
 
 import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useState, type ReactNode } from "react";
-import { createPortal } from "react-dom";
 import { Link } from "react-router";
 import { X } from "lucide-react";
 import { GLOSSARY_TERMS } from "../../data/glossary-data";
@@ -167,8 +166,7 @@ export function GlossaryWLink({ w }: { w: number }) {
       >
         W{w}
       </button>
-      {createPortal(
-        <ModalSheet
+      <ModalSheet
           open={open}
           onClose={() => setOpen(false)}
           ariaLabel={term.name}
@@ -281,9 +279,7 @@ export function GlossaryWLink({ w }: { w: number }) {
                 >
                   {cms.cooking.learnMore} →
                 </Link>
-        </ModalSheet>,
-        document.body,
-      )}
+        </ModalSheet>
     </>
   );
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -217,6 +217,7 @@
   --weight-medium: 500;
   --weight-semibold: 600;
   --weight-bold: 700;
+  --weight-extrabold: 800;
 
   /* ── Typography Primitives · Paragraph ── */
   --paragraph-spacing: 0.75em;
@@ -267,7 +268,6 @@
   --background: var(--color-parchment-50);
   --foreground: var(--color-night-1000);
   --card: var(--color-parchment-0);
-  --popover: var(--color-parchment-0);
   --primary: var(--color-terracotta-500);
   --ring: var(--color-terracotta-600);
   --primary-foreground: var(--color-white);
@@ -388,7 +388,6 @@
   --shadow-glow: 0 0 0 3px rgba(194, 74, 47, 0.14);
   --shadow-cta: 0 4px 14px rgba(45, 106, 79, 0.2);
 
-  --elevation-glow: var(--shadow-glow);
   --elevation-glow-lg: 0 0 0 4px rgba(194, 74, 47, 0.18);
   --elevation-cta: var(--shadow-cta);
 
@@ -830,7 +829,6 @@
   --background: var(--color-night-900);
   --foreground: var(--color-night-0);
   --card: var(--color-night-700);
-  --popover: var(--color-night-700);
   --primary: var(--color-terracotta-300);
   --ring: var(--color-terracotta-300);
   --primary-foreground: var(--color-terracotta-900);
@@ -939,7 +937,6 @@
   --shadow-glow: 0 0 0 3px rgba(244, 146, 106, 0.25);
   --shadow-cta: 0 4px 14px rgba(114, 200, 166, 0.18);
 
-  --elevation-glow: var(--shadow-glow);
   --elevation-glow-lg: 0 0 0 4px rgba(244, 146, 106, 0.3);
   --elevation-cta: var(--shadow-cta);
 


### PR DESCRIPTION
Follow-up di #28: applica i 10 finding della code review ad alto sforzo sul branch di allineamento bidirezionale.

## check:tokens (scripts/check-design-tokens.mjs)
- **Liveness con confini di identificatore**: il test `allSources.includes(t)` a substring rendeva immortale ogni token prefisso di un token più lungo (`--popover` restava vivo via `var(--popover-surface)`). Ora il match richiede un confine (`(?<![a-z0-9-])…(?![a-z0-9-])`), per token e composite. I due token morti scoperti (`--popover`, `--elevation-glow`, light+dark) sono stati rimossi da theme.css.
- **Niente più catch{} silenzioso**: il blocco bidirezionale era in un `try/catch` vuoto — qualunque errore runtime disattivava i check con esito verde. Ora c'è un guard `existsSync` esplicito e gli errori propagano.
- **theme.css letto senza commenti**: un token definito in un blocco commentato non viene più contato come definizione (falso positivo dead-token); stessa pulizia per i consumi `var()` interni.
- **Regex tw-raw-palette estesa**: ora copre `placeholder-`, `ring-offset-`, `inset-ring-` e i segmenti direzionali (`border-t-red-500`, `divide-x-*`) — classi che con la palette disattivata compilavano a nulla in silenzio e passavano il linter. Stessa estensione per la utilRe di liveness dei token `--color-*` (evita falsi dead-token su consumi direzionali).
- Nota: lo showcase resta incluso nella scansione di liveness — le sue pagine renderizzano davvero i token (swatch/demo); escluderlo flaggherebbe ~60 token vivi per /design-system.

## ModalSheet
- **Portal su document.body dentro il componente**: `fixed inset-0` si rompe sotto antenati con transform (pannelli motion draggabili); prima 2 call site su 5 portalavano a mano e 3 no. Rimossi i `createPortal` per-call-site (condiment-choice-strip, recipe-output-bits).

## Regressioni di clipping introdotte dalla migrazione a ModalSheet
- **recipe-learning-panel**: il cap `max-h-[85dvh]/80vh` + `overflow-hidden` rendeva irraggiungibile il contenuto lungo → pannello ora scrollabile (`overflow-y-auto overscroll-contain`).
- **condiment-choice-strip**: header+search+chip+lista (~750px) superavano l'80vh su finestre desktop medie e il fondo della lista veniva tagliato → pannello `flex flex-col` con lista `min-h-0` che si restringe sotto il cap.

## Altro
- **feedback-analysis**: il badge severità era regredito da 800 a 700 (`--weight-bold`) — aggiunto `--weight-extrabold: 800` e ripristinato il peso.
- **recipe-learning-panel**: `ariaLabel` italiano hardcoded → `aria-labelledby` sul titolo già renderizzato (regola CLAUDE.md: testo user-facing solo nel CMS).
- **condiment-choice-strip**: rimosso import `motion` morto.

Verifica: `npm run verify` (tsc + check:tokens + vitest) e `npm run build` verdi; regex nuove testate puntualmente (border-t-red-500/placeholder-red-400/ring-offset-* ora flaggate, bg-primary/text-semantic-* no; `--popover` morto flaggato, `type-data-sm` non tiene più vivo `type-data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)