### PR TITLE
feat(dev-tools): D1 via REST API (niente binding dashboard)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,19 +12,21 @@
 # VITE_ANNOTATIONS_KEY=some-shared-string
 
 # ── Cloudflare D1 setup (one-time) ──────────────────────────────────────────
-# Do NOT add a wrangler.toml to the repo: on a git-connected Pages project it
-# disables the dashboard bindings UI and forces a Workers-style `wrangler deploy`
-# that breaks the build. Configure the binding in the dashboard instead.
+# The Pages Function talks to D1 over its REST API, so NO dashboard "D1 binding"
+# is needed (that modal is flaky). Do NOT add a wrangler.toml either: on a
+# git-connected Pages project it disables the bindings UI and forces a broken
+# Workers-style `wrangler deploy`.
 #
-#   1. Create the DB (id already created: vulcan-annotations
-#      = 471d2a9d-1a54-418e-849c-479b85cbd979):
-#        npx wrangler d1 create vulcan-annotations
-#   2. Load the schema (resolves the DB by name — no wrangler.toml needed):
+#   1. DB already created: vulcan-annotations
+#      (id 471d2a9d-1a54-418e-849c-479b85cbd979, account ea8b6ef…354518 —
+#       both baked as defaults in functions/api/annotations.ts).
+#   2. Load the schema (resolves the DB by name):
 #        npx wrangler d1 execute vulcan-annotations --remote --file=./schema.sql
-#   3. Dashboard → your Pages project → Settings → Functions → D1 database
-#      bindings → Add: Variable name = DB, Database = vulcan-annotations
-#      (do it for Production; repeat for Preview if you want sync there too).
-#   4. Ensure the Build "Deploy command" is EMPTY (classic Pages git deploy);
+#   3. Create a Cloudflare API token with **D1 Edit** permission
+#      (dashboard → My Profile → API Tokens → Create → D1 template).
+#   4. Store it as a Pages secret (no dashboard modal needed):
+#        npx wrangler pages secret put D1_API_TOKEN --project-name <PAGES-PROJECT>
+#   5. Ensure the Build "Deploy command" is EMPTY (classic Pages git deploy);
 #      Build command = npm run build, output dir = dist. Then redeploy.
-#   5. (optional gate) npx wrangler pages secret put ANNOTATIONS_KEY
+#   6. (optional gate) npx wrangler pages secret put ANNOTATIONS_KEY
 #      + set VITE_ANNOTATIONS_KEY (build var) to the same value.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,11 +167,12 @@ production and — via `VITE_ANNOTATIONS_API` — the local dev app talk to. Eac
 entry carries `updatedAt`, plus `deleted` (tombstone) and `resolved` flags. If
 pins were created in production and dev isn't pointed at the same D1, run
 `VULCAN_ANNOTATIONS_API=… [VULCAN_ANNOTATIONS_KEY=…] npm run debug:pull` first to
-fold the remote registry into the local file. Backend setup (D1 create, schema
-load, dashboard binding `DB`) is documented in `.env.example` alongside
-`schema.sql`. Note: do **not** commit a `wrangler.toml` — on a git-connected
-Pages project it disables the dashboard bindings UI and forces a Workers-style
-`wrangler deploy` that fails the build.
+fold the remote registry into the local file. The Pages Function reaches D1 via
+its REST API (Pages secret `D1_API_TOKEN`, no dashboard binding); setup (schema
+load, token) is documented in `.env.example` alongside `schema.sql`. Note: do
+**not** commit a `wrangler.toml` — on a git-connected Pages project it disables
+the dashboard bindings UI and forces a Workers-style `wrangler deploy` that
+fails the build.
 
 If the user requests to "risolvi i commenti", "risolvi le annotazioni", "fix comments", or similar:
 1. Locate `vulcan-debug-registry.json` at the project root (run `npm run debug:pull` first if dev isn't wired to the same D1, so production pins are included).

--- a/functions/api/annotations.ts
+++ b/functions/api/annotations.ts
@@ -4,34 +4,31 @@
  * VITE_ANNOTATIONS_API) the local dev app talk to this single endpoint, so pins
  * sync across environments without a third-party service.
  *
+ * Talks to D1 over its **REST API** (not a runtime binding): the flaky
+ * dashboard "D1 bindings" UI is bypassed entirely. All it needs is a Cloudflare
+ * API token with D1 edit permission, stored server-side as the Pages secret
+ * `D1_API_TOKEN`. Account and database ids are non-secret and default to the
+ * project's values below (override with env vars if they ever change).
+ *
  * GET    → full registry (array of annotations, tombstones included)
  * POST   → upsert an array of annotations (last-write-wins by id), returns the
  *          canonical registry after the write
  * OPTIONS→ CORS preflight
  *
- * If the `ANNOTATIONS_KEY` env secret is set, every request must send a matching
- * `x-annotations-key` header. It ships in the client bundle so it is a soft gate
- * (stops casual/bot writes to a public URL), not real auth.
+ * If the `ANNOTATIONS_KEY` env is set, every request must send a matching
+ * `x-annotations-key` header (soft gate for a public URL, not real auth).
  *
- * This file lives under `functions/` and is intentionally outside the app
- * tsconfig `include`, so its Cloudflare-runtime types don't affect `tsc`.
+ * Lives under `functions/` — intentionally outside the app tsconfig `include`,
+ * so its Cloudflare-runtime types don't affect `tsc`.
  */
 
-interface D1Result {
-  results?: Record<string, unknown>[];
-}
-interface D1PreparedStatement {
-  bind(...values: unknown[]): D1PreparedStatement;
-  all(): Promise<D1Result>;
-  run(): Promise<unknown>;
-}
-interface D1Database {
-  prepare(query: string): D1PreparedStatement;
-  batch(statements: D1PreparedStatement[]): Promise<unknown>;
-}
+const DEFAULT_ACCOUNT_ID = "ea8b6efff9e61cb1427a489488354518";
+const DEFAULT_DATABASE_ID = "471d2a9d-1a54-418e-849c-479b85cbd979";
 
 interface Env {
-  DB: D1Database;
+  D1_API_TOKEN?: string;
+  CF_ACCOUNT_ID?: string;
+  CF_DATABASE_ID?: string;
   ANNOTATIONS_KEY?: string;
 }
 
@@ -55,13 +52,39 @@ function json(body: unknown, status = 200): Response {
 }
 
 function authorized(request: Request, env: Env): boolean {
-  if (!env.ANNOTATIONS_KEY) return true; // open when no key configured
+  if (!env.ANNOTATIONS_KEY) return true;
   return request.headers.get("x-annotations-key") === env.ANNOTATIONS_KEY;
 }
 
+/** Run one parameterized statement against D1's REST API; returns result rows. */
+async function d1Query(env: Env, sql: string, params: unknown[] = []): Promise<Record<string, unknown>[]> {
+  const accountId = env.CF_ACCOUNT_ID || DEFAULT_ACCOUNT_ID;
+  const databaseId = env.CF_DATABASE_ID || DEFAULT_DATABASE_ID;
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.D1_API_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql, params }),
+    },
+  );
+  const data = (await res.json()) as {
+    success?: boolean;
+    errors?: { message?: string }[];
+    result?: { results?: Record<string, unknown>[] }[];
+  };
+  if (!res.ok || !data.success) {
+    const msg = data.errors?.map((e) => e.message).join("; ") || `HTTP ${res.status}`;
+    throw new Error(`D1 query failed: ${msg}`);
+  }
+  return data.result?.[0]?.results ?? [];
+}
+
 async function readRegistry(env: Env): Promise<unknown[]> {
-  const { results } = await env.DB.prepare("SELECT data FROM annotations").all();
-  const rows = results ?? [];
+  const rows = await d1Query(env, "SELECT data FROM annotations");
   const out: unknown[] = [];
   for (const row of rows) {
     try {
@@ -80,6 +103,7 @@ export async function onRequestOptions(): Promise<Response> {
 export async function onRequestGet(context: EventContext): Promise<Response> {
   const { request, env } = context;
   if (!authorized(request, env)) return json({ error: "unauthorized" }, 401);
+  if (!env.D1_API_TOKEN) return json({ error: "D1_API_TOKEN secret not set" }, 500);
   try {
     return json(await readRegistry(env));
   } catch (e) {
@@ -90,6 +114,7 @@ export async function onRequestGet(context: EventContext): Promise<Response> {
 export async function onRequestPost(context: EventContext): Promise<Response> {
   const { request, env } = context;
   if (!authorized(request, env)) return json({ error: "unauthorized" }, 401);
+  if (!env.D1_API_TOKEN) return json({ error: "D1_API_TOKEN secret not set" }, 500);
 
   let incoming: unknown;
   try {
@@ -101,32 +126,26 @@ export async function onRequestPost(context: EventContext): Promise<Response> {
     return json({ error: "body must be an array of annotations" }, 400);
   }
 
-  const statements: D1PreparedStatement[] = [];
-  for (const anno of incoming) {
-    if (!anno || typeof (anno as { id?: unknown }).id !== "string") continue;
-    const record = anno as { id: string; updatedAt?: number; deleted?: boolean };
-    statements.push(
-      env.DB
-        .prepare(
-          `INSERT INTO annotations (id, data, updated_at, deleted)
-           VALUES (?1, ?2, ?3, ?4)
-           ON CONFLICT(id) DO UPDATE SET
-             data = excluded.data,
-             updated_at = excluded.updated_at,
-             deleted = excluded.deleted
-           WHERE excluded.updated_at >= annotations.updated_at`,
-        )
-        .bind(
-          record.id,
-          JSON.stringify(record),
-          typeof record.updatedAt === "number" ? record.updatedAt : 0,
-          record.deleted ? 1 : 0,
-        ),
-    );
-  }
+  const upsertSql = `INSERT INTO annotations (id, data, updated_at, deleted)
+     VALUES (?1, ?2, ?3, ?4)
+     ON CONFLICT(id) DO UPDATE SET
+       data = excluded.data,
+       updated_at = excluded.updated_at,
+       deleted = excluded.deleted
+     WHERE excluded.updated_at >= annotations.updated_at`;
 
   try {
-    if (statements.length > 0) await env.DB.batch(statements);
+    // Sequential to avoid write contention; the registry is small (a few pins).
+    for (const anno of incoming) {
+      if (!anno || typeof (anno as { id?: unknown }).id !== "string") continue;
+      const record = anno as { id: string; updatedAt?: number; deleted?: boolean };
+      await d1Query(env, upsertSql, [
+        record.id,
+        JSON.stringify(record),
+        typeof record.updatedAt === "number" ? record.updatedAt : 0,
+        record.deleted ? 1 : 0,
+      ]);
+    }
     return json(await readRegistry(env));
   } catch (e) {
     return json({ error: String((e as Error).message) }, 500);


### PR DESCRIPTION
Il modale 'D1 bindings' della dashboard Pages non risponde (probabile ad blocker o UI rotta), bloccando il setup. Questo PR **elimina la dipendenza dal binding**: la Pages Function chiama la **REST API di D1** con un API token salvato come Pages secret `D1_API_TOKEN` (server-side, mai nel client). Account e database id sono default overridabili via env.

**Setup ridotto a** (niente dashboard binding):
1. `npx wrangler d1 execute vulcan-annotations --remote --file=./schema.sql`
2. Crea un API token Cloudflare con permesso **D1 Edit**
3. `npx wrangler pages secret put D1_API_TOKEN --project-name <PROJECT>`
4. Deploy command vuoto → redeploy

Contratto JSON di `/api/annotations` invariato: client e `debug:pull` non cambiano. Verify verde, typecheck isolato della function ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)