### PR TITLE
fix(debug): risolvi le annotazioni aperte del debug overlay

### DIFF
--- a/src/app/components/shared/app-shell.tsx
+++ b/src/app/components/shared/app-shell.tsx
@@ -288,9 +288,17 @@ function useLiquidNavState(threshold = 28): LiquidNavState {
     let acc = 0;
     let frame = 0;
 
+    /* Massimo scroll reale della pagina. Su Safari iOS lo scrollY va oltre
+       questo valore (o sotto 0 in cima) durante il rubber-band: lo usiamo per
+       clampare ed evitare che l'elastico generi un dy fantasma. */
+    const maxScroll = () =>
+      Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+
     const readScroll = () => {
       frame = 0;
-      const y = window.scrollY;
+      /* Clamp anti rubber-band iOS: senza questo, l'overscroll in cima/fondo
+         produce delta spurii che fanno lampeggiare il dock. */
+      const y = Math.min(Math.max(window.scrollY, 0), maxScroll());
       const dy = y - lastY;
       lastY = y;
       const isScrolled = y > 24;
@@ -332,13 +340,27 @@ function useLiquidNavState(threshold = 28): LiquidNavState {
       frame = window.requestAnimationFrame(readScroll);
     };
 
+    /* Comparsa/scomparsa della barra indirizzi Safari iOS: emette resize (e
+       visualViewport resize) senza uno scroll reale dell'utente. La trattiamo
+       come "mostra il dock" e ri-sincronizziamo lastY, così la barra che
+       ricompare non lascia il dock nascosto né provoca un flip spurio. */
+    const onViewportChange = () => {
+      lastY = Math.min(Math.max(window.scrollY, 0), maxScroll());
+      acc = 0;
+      setState((prev) => (prev.hidden ? { ...prev, hidden: false } : prev));
+    };
+
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
     document.addEventListener("scroll", onScroll, { passive: true, capture: true });
+    window.addEventListener("resize", onViewportChange, { passive: true });
+    window.visualViewport?.addEventListener("resize", onViewportChange);
     return () => {
       if (frame) window.cancelAnimationFrame(frame);
       window.removeEventListener("scroll", onScroll);
       document.removeEventListener("scroll", onScroll, { capture: true } as EventListenerOptions);
+      window.removeEventListener("resize", onViewportChange);
+      window.visualViewport?.removeEventListener("resize", onViewportChange);
     };
   }, [threshold]);
   return state;
@@ -394,10 +416,10 @@ function BottomTabBar({
         <motion.span
           aria-hidden="true"
           className="pointer-events-none absolute inset-x-0 top-0 h-px"
-          animate={{ opacity: 0.44 }}
+          animate={{ opacity: 0.26 }}
           style={{
             background:
-              "linear-gradient(to right, transparent, color-mix(in srgb, var(--overlay-text) 36%, transparent) 15%, color-mix(in srgb, var(--overlay-text) 36%, transparent) 85%, transparent)",
+              "linear-gradient(to right, transparent, color-mix(in srgb, var(--overlay-text) 20%, transparent) 30%, color-mix(in srgb, var(--overlay-text) 20%, transparent) 70%, transparent)",
           }}
         />
         <div

--- a/src/app/features/cms/cms-context.tsx
+++ b/src/app/features/cms/cms-context.tsx
@@ -148,7 +148,7 @@ export interface CmsUiStrings {
   weatherOutdoor: string;       // "{t}°C fuori" template
   weatherKitchen: string;       // "Cucina"
   // Badges
-  badgeIdeal: string;           // "Più rapido" — slot temporale più vicino (non un giudizio di qualità)
+  badgeIdeal: string;           // "Consigliato" — slot con fermentazione più vicina a ~24h (finestra ideale, non il più rapido)
   badgeRecent: string;          // "RECENTE"
   autoLabel: string;            // "Auto"
   // Oven compact bar
@@ -731,6 +731,9 @@ export interface CmsContent {
     tabRecipeTailored: string;
     /** Etichetta stato ricetta non personalizzata (pill contesto + occhiello). */
     recipeCanonical: string;
+    /** Occhiello hero: variante canonica senza ripetere "Ricetta" (già nel tab).
+     *  Opzionale: i locali che non la definiscono ricadono su recipeCanonical. */
+    recipeCanonicalEyebrow?: string;
     /** Dialog pre-cottura: la ricetta canonica non è ancora adattata. */
     preCookTitle: string;
     preCookBody: string;
@@ -1429,6 +1432,7 @@ export const CMS_DEFAULTS: CmsContent = {
     tabRecipe: "Ricetta",
     tabRecipeTailored: "Ricetta su misura",
     recipeCanonical: "Ricetta canonica",
+    recipeCanonicalEyebrow: "Canonica",
     preCookTitle: "Prima di accendere il forno",
     preCookBody:
       "Questa è ancora la ricetta originale. Puoi partire così, oppure adattarla al tuo forno e ai tuoi tempi prima di iniziare la pizzata.",

--- a/src/app/features/cms/locales/en.ts
+++ b/src/app/features/cms/locales/en.ts
@@ -397,6 +397,7 @@ export const EN_LOCALE: CmsContent = {
     tabRecipe: "Recipe",
     tabRecipeTailored: "Tailored recipe",
     recipeCanonical: "Canonical recipe",
+    recipeCanonicalEyebrow: "Canonical",
     preCookTitle: "Before you fire up the oven",
     preCookBody:
       "This is still the original recipe. You can start as is, or adapt it to your oven and your schedule before the bake.",

--- a/src/app/pages/explore.tsx
+++ b/src/app/pages/explore.tsx
@@ -24,7 +24,6 @@ type PizzaStyle,
 type UserConstraints,
 } from "../domain/pizza-engine";
 import { STYLE_PHOTOS } from "../features/recipe/recommended-styles";
-import { ScoreRing } from "../features/recipe/score-ring";
 import { useProfileDefaults } from "../hooks/use-profile-defaults";
 import {
 SIGNATURE_RECIPES,
@@ -231,7 +230,7 @@ export function ExplorePage() {
   const { cms } = useCms();
   const { effectiveStyles } = useStylesOverride();
   // Fase 4: Scopri è il polo CANONICO. Le card mostrano il match canonico sul tuo
-  // forno (M_c) con una scia fantasma fino al soffitto ottimizzabile (M_o).
+  // forno (M_c) e, quando il margine è reale, la pill "M_c% → M_o%" col soffitto ottimizzabile.
   const { constraints: profileConstraints } = useProfileDefaults();
   const [searchParams, setSearchParams] = useSearchParams();
   const urlFilter = searchParams.get("view");

--- a/src/app/pages/explore.tsx
+++ b/src/app/pages/explore.tsx
@@ -158,6 +158,7 @@ function FeaturedRecipeCard({
               backdropFilter: "blur(8px)",
               fontSize: "var(--font-size-base)",
               fontWeight: "var(--weight-semibold)",
+              cursor: getAcronymTooltip(recipe.authenticity_badge) ? "help" : undefined,
             }}
           >
             {recipe.authenticity_badge}
@@ -317,7 +318,10 @@ export function ExplorePage() {
         color: "var(--text-default)",
       }}
     >
-      {isNerd && <FireGlow intensity={0.3} variant="warm" />}
+      {/* Glow sempre attivo (feedback: "rendiamolo evidente in entrambi i mode",
+          non solo nerd). Un filo più intenso fuori dalla modalità nerd così
+          emerge anche su light, dove il warm si legge meno che su dark. */}
+      <FireGlow intensity={isNerd ? 0.3 : 0.36} variant="warm" />
       <motion.div
         initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
@@ -767,6 +771,7 @@ function SignatureRecipeCard({
                 fontWeight: "var(--weight-semibold)" as any,
                 color: "white",
                 backdropFilter: "blur(8px)",
+                cursor: getAcronymTooltip(recipe.authenticity_badge) ? "help" : undefined,
               }}
             >
               {recipe.authenticity_badge}
@@ -939,6 +944,7 @@ function StyleCatalogCard({
                   boxShadow: "0 4px 12px color-mix(in srgb, var(--shadow-color) 16%, transparent)",
                 }}
                 title={match.headroom > 0 ? `Ottimizzabile: ${match.mc}% → ${match.mc + match.headroom}% col tuo setup` : `Match: ${match.mc}%`}
+                aria-label={match.headroom > 0 ? `Compatibilità ${match.mc}%, ottimizzabile fino a ${match.mc + match.headroom}% col tuo setup` : `Compatibilità ${match.mc}%`}
               >
                 <span style={{ color: "var(--cta)" }}>{match.mc}%</span>
                 {match.headroom > 0 && (

--- a/src/app/pages/home.tsx
+++ b/src/app/pages/home.tsx
@@ -1619,7 +1619,7 @@ export function HomePage() {
               eyebrow={
                 createDirty
                   ? cms.cooking.recipeAdapted
-                  : cms.cooking.recipeCanonical
+                  : cms.cooking.recipeCanonicalEyebrow ?? cms.cooking.recipeCanonical
               }
               eyebrowTone={createDirty ? "tailored" : "canonical"}
               shareUrl={shareUrl}

--- a/src/app/pages/recipe.tsx
+++ b/src/app/pages/recipe.tsx
@@ -1008,7 +1008,7 @@ function RecipeContent({
       ? cmsMessage(cms, "recipeMode.lab", "Laboratorio")
       : isDirty
         ? cms.cooking.recipeAdapted
-        : cmsMessage(cms, "recipeMode.canonical", cms.cooking.recipeCanonical);
+        : cmsMessage(cms, "recipeMode.canonical", cms.cooking.recipeCanonicalEyebrow ?? cms.cooking.recipeCanonical);
 
   /* Photo */
   const photo =

--- a/vulcan-debug-registry.json
+++ b/vulcan-debug-registry.json
@@ -45,8 +45,9 @@
     "comment": "Andrebbe sistemata posizione navbar e sfumatura sotto. Anche il comportamento on-scroll è da decidere (considera ad es Safari su iphone che sotto ha la barra indirizzi)",
     "priority": "high",
     "index": 1,
-    "updatedAt": 1783283968000,
-    "deleted": true
+    "updatedAt": 1783283969000,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783170718236",
@@ -88,8 +89,9 @@
     "comment": "Sigle come AVPN o STG: dove abbiamo spazio, o lescriviamo per intero o mettiamo un tip",
     "priority": "low",
     "index": 2,
-    "updatedAt": 1783283968000,
-    "deleted": true
+    "updatedAt": 1783283969001,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783170828747",
@@ -131,8 +133,9 @@
     "comment": "scrivere ogni volta \"ricetta\" è ridondante",
     "priority": "medium",
     "index": 3,
-    "updatedAt": 1783283968000,
-    "deleted": true
+    "updatedAt": 1783283969002,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783170865598",
@@ -174,8 +177,9 @@
     "comment": "questo arco fantasma non mi sembra abbia avuto molto successo... Troviamo un altro modo per mostrare in modo semplice e esplicito a quanto può arrivare il match",
     "priority": "medium",
     "index": 4,
-    "updatedAt": 1783283968000,
-    "deleted": true
+    "updatedAt": 1783283969003,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783192002768",
@@ -217,8 +221,9 @@
     "comment": "\"Più rapido\" sarà sempre la prima scelta, che valore aggiunto mi dà? O troviamo un suggerimento valido, o togliamo",
     "priority": "medium",
     "index": 5,
-    "updatedAt": 1783283968000,
-    "deleted": true
+    "updatedAt": 1783283969004,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783192065657",
@@ -260,8 +265,9 @@
     "comment": "controllare riflesso \"glass\" su border top, sembra strano",
     "priority": "low",
     "index": 6,
-    "updatedAt": 1783283968000,
-    "deleted": true
+    "updatedAt": 1783283969005,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783192140444",
@@ -303,7 +309,7 @@
     "comment": "è bello questo glow, su dark rende meglio che su light. Troviamo modo di farlo + evidente in entrambi i mode",
     "priority": "low",
     "index": 7,
-    "updatedAt": 1783283968000,
+    "updatedAt": 1783283969006,
     "deleted": false,
     "resolved": true
   }


### PR DESCRIPTION
## Contesto

Sette annotazioni del debug overlay risultavano **LIVE nel D1** (la fonte autoritativa che l'overlay legge davvero) pur essendo marcate come tombstone (`deleted: true`) nel `vulcan-debug-registry.json` committato — con un `updatedAt` bulk identico (`1783283968000`), sintomo di una cancellazione accidentale mai sincronizzata. Recuperate via `npm run debug:pull` dal Worker di produzione e lavorate tutte.

## Modifiche per annotazione

| # | Feedback | Intervento |
|---|----------|-----------|
| 1 | Navbar mobile: posizione + comportamento on-scroll da rivedere (Safari iOS con barra indirizzi in basso) | `useLiquidNavState`: clamp del rubber-band overscroll iOS (niente più `dy` fantasma) e gestione del resize di `visualViewport`/`window` come "mostra dock" invece di flip spurio quando la barra indirizzi compare/scompare |
| 2 | Sigle AVPN/STG: full-text o un tip dove c'è spazio | `getAcronymTooltip` già forniva il tip nativo (`title`); aggiunto `cursor: help` sui badge che ne hanno uno, così diventa scopribile |
| 3 | "Ricetta" ridondante nell'occhiello delle card | Nuova chiave CMS opzionale `recipeCanonicalEyebrow` (`"Canonica"` / `"Canonical"`) usata solo dall'occhiello hero, così non ripete la "Ricetta" già presente nel tab. La pill di contesto in `recipe-output` resta invariata |
| 4 | "Arco fantasma" del match poco efficace | L'arco era già stato sostituito dalla pill `mc% → mo%`; aggiunto `aria-label` esplicito per chiarezza/accessibilità |
| 5 | Badge "Più rapido" senza valore aggiunto | Era già rietichettato "Consigliato"/"Recommended" in tutti i locali; allineato il commento stale nell'interfaccia CMS |
| 6 | Riflesso "glass" sul border-top del dock "sembra strano" | Ammorbidito: `opacity` 0.44 → 0.26 e `color-mix` 36% → 20% |
| 7 | Glow bello ma rende meglio su dark che su light | `FireGlow` su `/explore` reso **sempre attivo** (non solo modalità nerd) e un filo più intenso fuori dal nerd, così emerge anche in light mode |

## Registry

Le 7 voci gestite → `resolved: true`, `deleted: false`, `updatedAt` bumpato **sopra ogni timestamp noto** (incluso il vecchio tombstone `1783283968000`), così la risoluzione vince in last-write-wins su tutti i layer (localStorage / file dev / D1). Il tombstone di test `e2e-test-*` resta invariato.

## Verifica

- `tsc --noEmit` → pulito
- `npm run check:tokens` → 0 violazioni (nessun hardcode, tutto su token `theme.css`)
- `vitest run` → 31/31 test verdi
- `npm run build` → build di produzione ok

> Nota: `npm run verify` incontra un errore **preesistente** di deprecazione `baseUrl` in `tsconfig.json` (presente anche su `main`, non introdotto qui); il type-check è stato eseguito con `--ignoreDeprecations 5.0` senza toccare la config.

## Note per il review

- #1 (scroll iOS) e #7 (glow) erano scelte di prodotto: direzione confermata con l'owner prima di implementare. Sono le più soggettive — feedback benvenuto.
- #4 e #5 erano già di fatto risolte nel codice: qui aggiungo solo rifiniture e allineo la documentazione/registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cq2b3kuR4WeS6moPyD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dw8Cq2b3kuR4WeS6moPyD9)_