### PR TITLE
fix(debug): ripristina il triple-tap per attivare/disattivare l'AI debugger

### DIFF
--- a/src/app/features/dev-tools/debug/use-debug-gate.ts
+++ b/src/app/features/dev-tools/debug/use-debug-gate.ts
@@ -50,24 +50,52 @@ export function useDebugGate() {
 
     let lastTap = 0;
     let tapCount = 0;
+    let replayTimer: number | null = null;
+    let replayTarget: HTMLElement | null = null;
+    const clearReplay = () => {
+      if (replayTimer !== null) window.clearTimeout(replayTimer);
+      replayTimer = null;
+      replayTarget = null;
+    };
     const handleTouchEnd = (e: TouchEvent) => {
       const touch = e.changedTouches[0];
       const inHotCorner = touch && touch.clientX < HOT_CORNER_PX && touch.clientY < HOT_CORNER_PX;
       if (!inHotCorner) {
         tapCount = 0;
+        clearReplay();
         return;
       }
+
+      /* Alcune pagine mostrano un pulsante flottante (es. "indietro" su
+       * /recipe) proprio in questo angolo: senza questa esclusione il primo
+       * tocco navigava via prima che i 3 tocchi potessero completarsi.
+       * Sospendiamo il default e lo "ripetiamo" se non è un triplo-tap, così
+       * il pulsante resta invariato per chi tocca una volta sola. */
+      const target = touch.target as HTMLElement | null;
+      const isDebugUi = !!target?.closest("#vulcan-debug-ui, .vulcan-debug-exclude");
+      const interactiveTarget = isDebugUi
+        ? null
+        : (target?.closest("a,button,[role='button']") as HTMLElement | null);
+      if (interactiveTarget) e.preventDefault();
+
       const now = Date.now();
-      if (now - lastTap < 350) {
-        tapCount++;
-        if (tapCount >= 3) {
-          toggle();
-          tapCount = 0;
-        }
-      } else {
-        tapCount = 1;
-      }
+      tapCount = now - lastTap < 350 ? tapCount + 1 : 1;
       lastTap = now;
+
+      clearReplay();
+      if (tapCount >= 3) {
+        tapCount = 0;
+        toggle();
+        return;
+      }
+      if (interactiveTarget) {
+        replayTarget = interactiveTarget;
+        replayTimer = window.setTimeout(() => {
+          replayTarget?.click();
+          replayTimer = null;
+          replayTarget = null;
+        }, 350);
+      }
     };
 
     window.addEventListener("keydown", handleGlobalKeys);
@@ -75,6 +103,7 @@ export function useDebugGate() {
     return () => {
       window.removeEventListener("keydown", handleGlobalKeys);
       window.removeEventListener("touchend", handleTouchEnd);
+      clearReplay();
     };
   }, [toggle]);
 


### PR DESCRIPTION
## Contesto

Follow-up alla #36 (già mergiata): l'utente ha segnalato che il triple-tap per **spegnere** l'AI debug overlay non funzionava più.

## Causa

Verificata empiricamente (Playwright, viewport mobili reali, `document.elementFromPoint` su `/recipe/:id`), non solo per deduzione: sulla pagina ricetta, il pulsante flottante "indietro" (`top-4 left-4`, 48px, introdotto il 2 luglio) occupa esattamente l'hot corner 64×64px del gesture di triple-tap (0–64px in entrambi gli assi, `use-debug-gate.ts`). Il primo tocco della sequenza colpiva quel bottone reale e **navigava via** prima che i 3 tocchi potessero completarsi — per questo su quella pagina "spegnere" l'overlay con 3 tocchi sull'angolo non funzionava più.

## Fix

In `useDebugGate` (`src/app/features/dev-tools/debug/use-debug-gate.ts`): quando un tocco nell'hot corner colpisce un elemento interattivo reale (non l'UI del debugger), sospendiamo il suo comportamento di default (`preventDefault`) e lo "ripetiamo" via `replayTarget.click()` dopo 350ms **solo se** la sequenza non arriva a 3 tocchi. Così:
- un tocco singolo normale naviga ancora (con un ritardo trascurabile, ~350ms al massimo, solo in quello specifico angolo 64×64px)
- un triplo-tap rapido non viene più interrotto dalla navigazione

## Verifica

- `tsc --noEmit` → pulito
- `npm run check:tokens` → 0 violazioni
- `vitest run` → 31/31 test verdi
- **End-to-end reale** (Playwright, iPhone SE viewport, `/recipe/:id`):
  - 1 tocco nell'angolo → naviga comunque (nessuna regressione per l'uso normale) ✅
  - 3 tocchi rapidi nell'angolo → overlay ON→OFF **e** OFF→ON, pagina invariata ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cq2b3kuR4WeS6moPyD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dw8Cq2b3kuR4WeS6moPyD9)_