### PR TITLE
fix(debug): rendi affidabile il triple-tap su mobile (angolo hot-corner + timing)

### DIFF
--- a/src/app/features/dev-tools/debug/use-debug-gate.ts
+++ b/src/app/features/dev-tools/debug/use-debug-gate.ts
@@ -1,9 +1,34 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const ENABLED_KEY = "vulcan_debug_overlay_enabled";
-// Triple-tap only arms the debugger inside this top-left hot corner, so a normal
-// user tapping around the UI can't accidentally summon the dev overlay.
-const HOT_CORNER_PX = 64;
+// Triple-tap arms the debugger only inside this top-left hot corner, so a normal
+// user tapping around the UI can't accidentally summon the dev overlay. It is a
+// generous square: on notched phones (viewport-fit=cover) the top ~50px render
+// UNDER the status bar and the OS eats taps there, so a tiny 64px corner sat
+// almost entirely in dead space — the gesture stopped registering. We both
+// enlarge the square AND offset it below env(safe-area-inset-top).
+const HOT_CORNER_PX = 100;
+// Max gap between taps of the triple-tap. Aiming for a small corner makes a
+// deliberate human triple-tap noticeably slower than a synthetic one, so keep
+// this generous — any pause longer than this simply resets the counter.
+const TRIPLE_TAP_WINDOW_MS = 700;
+
+/** Height of the top safe-area inset (iOS status bar / notch) in CSS px.
+ *  Taps in that band are captured by the OS, so the hot corner must start
+ *  below it. Measured from env(safe-area-inset-top); 0 where unsupported. */
+function readSafeAreaTop(): number {
+  try {
+    const probe = document.createElement("div");
+    probe.style.cssText =
+      "position:fixed;top:0;left:0;width:0;height:env(safe-area-inset-top,0px);visibility:hidden;pointer-events:none";
+    document.body.appendChild(probe);
+    const h = probe.getBoundingClientRect().height;
+    probe.remove();
+    return Number.isFinite(h) ? h : 0;
+  } catch {
+    return 0;
+  }
+}
 
 /**
  * Lightweight always-mounted gate for the AI debugger. Owns only the enable
@@ -48,6 +73,13 @@ export function useDebugGate() {
       }
     };
 
+    // Refreshed on mount + orientation/resize: the inset changes when the
+    // device rotates, so the hot corner tracks the current status-bar height.
+    let safeAreaTop = readSafeAreaTop();
+    const refreshSafeArea = () => {
+      safeAreaTop = readSafeAreaTop();
+    };
+
     let lastTap = 0;
     let tapCount = 0;
     let replayTimer: number | null = null;
@@ -59,7 +91,13 @@ export function useDebugGate() {
     };
     const handleTouchEnd = (e: TouchEvent) => {
       const touch = e.changedTouches[0];
-      const inHotCorner = touch && touch.clientX < HOT_CORNER_PX && touch.clientY < HOT_CORNER_PX;
+      /* Il vertice parte SOTTO la safe-area: su iPhone col notch il contenuto
+       * scorre sotto la status bar, quindi il vero angolo visibile che l'utente
+       * tocca sta a y ≈ safeAreaTop..(safeAreaTop+100), non a 0..64. */
+      const inHotCorner =
+        !!touch &&
+        touch.clientX < HOT_CORNER_PX &&
+        touch.clientY < safeAreaTop + HOT_CORNER_PX;
       if (!inHotCorner) {
         tapCount = 0;
         clearReplay();
@@ -79,7 +117,7 @@ export function useDebugGate() {
       if (interactiveTarget) e.preventDefault();
 
       const now = Date.now();
-      tapCount = now - lastTap < 350 ? tapCount + 1 : 1;
+      tapCount = now - lastTap < TRIPLE_TAP_WINDOW_MS ? tapCount + 1 : 1;
       lastTap = now;
 
       clearReplay();
@@ -94,15 +132,21 @@ export function useDebugGate() {
           replayTarget?.click();
           replayTimer = null;
           replayTarget = null;
-        }, 350);
+        }, TRIPLE_TAP_WINDOW_MS);
       }
     };
 
     window.addEventListener("keydown", handleGlobalKeys);
-    window.addEventListener("touchend", handleTouchEnd);
+    // passive:false — chiamiamo preventDefault() quando il tocco cade su un
+    // pulsante reale nell'angolo (vedi replay sopra).
+    window.addEventListener("touchend", handleTouchEnd, { passive: false });
+    window.addEventListener("resize", refreshSafeArea, { passive: true });
+    window.addEventListener("orientationchange", refreshSafeArea, { passive: true });
     return () => {
       window.removeEventListener("keydown", handleGlobalKeys);
       window.removeEventListener("touchend", handleTouchEnd);
+      window.removeEventListener("resize", refreshSafeArea);
+      window.removeEventListener("orientationchange", refreshSafeArea);
       clearReplay();
     };
   }, [toggle]);


### PR DESCRIPTION
## Contesto

Il triple-tap per attivare/disattivare l'AI debug overlay non funzionava su mobile. La #37 aveva corretto un problema **secondario** (il pulsante "indietro" su `/recipe`), ma l'utente continuava a segnalare che non andava — testando su **home/explore**, dove nell'angolo non c'è alcun bottone. La #37 non poteva aiutare lì: la causa era un'altra.

## Causa reale

Il refactor lazy del 4 luglio (`ca0c4ee`) ha introdotto il vincolo `HOT_CORNER_PX = 64` che **prima non esisteva** (fino ad allora bastavano 3 tocchi *ovunque* sullo schermo). Quell'angolo da 64px è inutilizzabile su un telefono vero: con `viewport-fit=cover`, i primi ~50px in alto stanno **sotto la status bar / notch** (`env(safe-area-inset-top)`) e l'OS intercetta i tocchi lì. Il vero angolo visibile che l'utente tocca cade a **y≈60–100px**, cioè fuori dalla soglia di 64px → i tocchi non venivano contati. Per questo falliva su **tutte** le pagine.

## Correzioni al meccanismo di base

In `useDebugGate` (`src/app/features/dev-tools/debug/use-debug-gate.ts`):

- **L'angolo parte SOTTO la safe-area**: soglia verticale = `env(safe-area-inset-top) + 100px`, misurata a runtime e ricalcolata su `resize`/`orientationchange`. Larghezza 64→100px per la tolleranza del pollice.
- **Finestra triple-tap 350→700ms**: mirare a un angolo piccolo rende il gesto deliberato più lento di uno sintetico; 350ms era troppo stretto per un umano.
- `touchend` con `{ passive: false }` (necessario per il `preventDefault` del replay).
- Mantenuta la logica di replay del tap sui pulsanti nell'angolo (es. "indietro" su `/recipe`): un tocco singolo naviga ancora, il triple-tap non viene interrotto.

## Verifica (empirica, non solo tsc)

Playwright, viewport iPhone `375×667` con `hasTouch`, tocchi reali:
- Triple-tap a coordinate realistiche (y≈75–85) **attiva e disattiva** l'overlay su `/`, `/explore`, `/learn`, `/profile`, `/recipe` con gap da 300 a 600ms ✅
- Tocco al **centro schermo** o con **pausa lunga** → NON attiva (nessun trigger accidentale) ✅
- Su `/recipe`: triple-tap sul pulsante indietro spegne senza navigare; **tocco singolo naviga ancora**; triple-tap sulla parte non-bottone dell'angolo attiva ✅
- `tsc --noEmit` pulito · `check:tokens` 0 violazioni · `vitest` 31/31

> Nota: `npm run verify` incontra la stessa deprecazione `baseUrl` preesistente in `tsconfig.json` (presente anche su `main`); il type-check è stato eseguito con `--ignoreDeprecations 5.0` senza toccare la config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw8Cq2b3kuR4WeS6moPyD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dw8Cq2b3kuR4WeS6moPyD9)_