### PR TITLE
Fix client UI annotation batch

### DIFF
--- a/knowledge/workflow-state.json
+++ b/knowledge/workflow-state.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-07-09T08:15:00.000Z",
+  "lastUpdated": "2026-07-10T01:10:00.000Z",
   "project": "Vulcan",
   "sourceStats": {
     "srcFilesTsTsx": 151,
@@ -10,11 +10,11 @@
     "stylesInDb": 29
   },
   "coveragePercent": 100,
-  "coverageNote": "10/10 capitoli con scan profondo completato; l'update 2026-07-09 registra la rimozione dei vecchi temi switchabili sperimentali (Editoriale, Classica, Minimal), dei relativi fogli stile e font non utilizzati per ottimizzare il bundle, e il salvataggio del token --density-spacious in staging in check-design-tokens.mjs.",
+  "coverageNote": "10/10 capitoli con scan profondo completato; l'update 2026-07-10 registra la nascita delle tre nuove direzioni tipografiche (Riserva, Lettera, Copertina), il controllo datetime-local completo sulle ore di fermentazione in ProcedureHero, la revisione del selettore profili di calore forno (Statico, Ventilato, Gas sotto/dietro, Legna) ed il layout delle ricette salvate vuote sul Profilo.",
   "filesMappedCount": 151,
   "nextRecommendedScan": null,
   "nextRecommendedScanMessage": "KB sincronizzata — usare kipi update dopo modifiche codice",
-  "lastScannedChapter": "kipi-update-2026-07-09",
+  "lastScannedChapter": "kipi-update-2026-07-10",
   "chapters": [
     {
       "id": "pizza-engine",

--- a/src/app/components/design-system/foundations-contrast-density.tsx
+++ b/src/app/components/design-system/foundations-contrast-density.tsx
@@ -82,7 +82,7 @@ const ALL_PAIRS: ContrastPair[] = [
   { id: "cta-cbg", fgVar: "--cta-foreground", bgVar: "--cta", label: "CTA FG / CTA", category: "semantic", required: "AA" },
   { id: "destr-dbg", fgVar: "--destructive-foreground", bgVar: "--destructive", label: "Destructive FG / Destructive", category: "semantic", required: "AA" },
   { id: "muted-bg", fgVar: "--muted-foreground", bgVar: "--background", label: "Muted FG / Background", category: "semantic", required: "AA" },
-  { id: "primary-bg", fgVar: "--primary", bgVar: "--background", label: "Primary / Background", category: "semantic", required: "AA18" },
+  { id: "primary-bg", fgVar: "--primary", bgVar: "--background", label: "Primary / Background", category: "semantic", required: "AA" },
 
   /* ── M3 Container (tonal) ── */
   { id: "pc-opc", fgVar: "--on-primary-container", bgVar: "--primary-container", label: "on-primary-container / primary-container", category: "container", required: "AA" },
@@ -98,9 +98,18 @@ const ALL_PAIRS: ContrastPair[] = [
   /* ── Cross-component (common patterns) ── */
   { id: "fg-surfcl", fgVar: "--foreground", bgVar: "--surface-container-low", label: "foreground / surface-container-low", category: "cross", required: "AAA" },
   { id: "muted-surfcl", fgVar: "--muted-foreground", bgVar: "--surface-container-low", label: "muted-foreground / surface-container-low", category: "cross", required: "AA" },
-  { id: "muted-surfcont", fgVar: "--muted-foreground", bgVar: "--surface-container", label: "muted-foreground / surface-container", category: "cross", required: "AA18" },
-  { id: "primary-surfch", fgVar: "--primary", bgVar: "--surface-container-high", label: "primary / surface-container-high (FAB surface)", category: "cross", required: "AA18" },
+  { id: "muted-surfcont", fgVar: "--muted-foreground", bgVar: "--surface-container", label: "muted-foreground / surface-container", category: "cross", required: "AA" },
+  { id: "primary-surfch", fgVar: "--primary", bgVar: "--surface-container-high", label: "primary / surface-container-high (non-text icon)", category: "cross", required: "AA18" },
   { id: "fg-surfch", fgVar: "--foreground", bgVar: "--surface-container-high", label: "foreground / surface-container-high", category: "cross", required: "AA" },
+  { id: "text-default-page", fgVar: "--text-default", bgVar: "--container-page", label: "text-default / container-page", category: "cross", required: "AAA" },
+  { id: "text-muted-page", fgVar: "--text-muted", bgVar: "--container-page", label: "text-muted / container-page", category: "cross", required: "AA" },
+  { id: "text-muted-container", fgVar: "--text-muted", bgVar: "--container-bg", label: "text-muted / container-bg", category: "cross", required: "AA" },
+  { id: "text-subtle-container", fgVar: "--text-subtle", bgVar: "--container-bg", label: "text-subtle / container-bg", category: "cross", required: "AA" },
+  { id: "text-accent-page", fgVar: "--text-accent", bgVar: "--container-page", label: "text-accent / container-page", category: "cross", required: "AA" },
+  { id: "text-accent-container", fgVar: "--text-accent", bgVar: "--container-bg", label: "text-accent / container-bg", category: "cross", required: "AA" },
+  { id: "text-success-page", fgVar: "--text-success", bgVar: "--container-page", label: "text-success / container-page", category: "cross", required: "AA" },
+  { id: "text-warning-page", fgVar: "--text-warning", bgVar: "--container-page", label: "text-warning / container-page", category: "cross", required: "AA" },
+  { id: "text-error-page", fgVar: "--text-error", bgVar: "--container-page", label: "text-error / container-page", category: "cross", required: "AA" },
 ];
 
 /* ═══════════════════════════════════════════════════════════

--- a/src/app/components/ds/FilterChip.tsx
+++ b/src/app/components/ds/FilterChip.tsx
@@ -58,7 +58,9 @@ export function FilterChip({
         .filter(Boolean)
         .join(" ")}
       style={style}
+      layout
       whileHover={{ y: -1 }}
+      whileTap={{ scale: 0.96 }}
       transition={{ type: "spring", stiffness: 500, damping: 30 }}
       {...props}
     >

--- a/src/app/components/shared/app-shell.tsx
+++ b/src/app/components/shared/app-shell.tsx
@@ -158,11 +158,6 @@ const premiumGlassStyle: React.CSSProperties = {
   boxShadow: "var(--premium-glass-shadow)",
 };
 
-const mobileDockGlassStyle: React.CSSProperties = {
-  ...premiumGlassStyle,
-  background: "color-mix(in srgb, var(--container-page) 94%, transparent)",
-};
-
 function getActiveTab(pathname: string): string | null {
   /* Exact match for "/" to avoid matching everything */
   if (pathname === "/") return "create";
@@ -337,12 +332,12 @@ function BottomTabBar({
   const { hidden, scrolled } = navState;
   return (
     <motion.div
-      className={`app-shell-dock${scrolled ? " app-shell-dock--scrolled" : ""}`}
+      className={`app-shell-dock${scrolled ? " app-shell-dock--scrolled" : ""}${hidden ? " app-shell-dock--hidden" : ""}`}
       initial={{ y: 0, scale: 1, opacity: 1 }}
       animate={{
-        y: hidden && !prefersReducedMotion ? 16 : 0,
-        scale: hidden && !prefersReducedMotion ? 0.985 : scrolled ? 0.99 : 1,
-        opacity: hidden ? 0.88 : 1,
+        y: hidden && !prefersReducedMotion ? 96 : 0,
+        scale: hidden && !prefersReducedMotion ? 0.98 : scrolled ? 0.99 : 1,
+        opacity: hidden ? 0 : 1,
       }}
       transition={
         prefersReducedMotion
@@ -382,7 +377,7 @@ function BottomTabBar({
         diameter={56}
         iconSize={24}
         onOpen={onSearchOpen}
-        surfaceStyle={mobileDockGlassStyle}
+        surfaceStyle={premiumGlassStyle}
       />
     </motion.div>
   );
@@ -423,10 +418,10 @@ function SidebarRail({
           className="app-shell-rail__logo"
           aria-label={cms.pages.homeAria}
         >
-          <VulcanMark size={20} decorative />
+          <VulcanMark size={22} decorative />
         </Link>
 
-        {/* Tabs — centrate verticalmente nella capsula (M3 rail) */}
+        {/* Tabs */}
         <div className="app-shell-rail__tabs">
           {TABS.map((tab) => (
             <TabItem
@@ -436,6 +431,15 @@ function SidebarRail({
               layout="rail"
             />
           ))}
+        </div>
+
+        <div className="app-shell-rail__search">
+          <SearchButton
+            diameter={44}
+            iconSize={20}
+            onOpen={onSearchOpen}
+            surfaceStyle={premiumGlassStyle}
+          />
         </div>
 
         {/* Dev shortcut (subtle) */}
@@ -453,13 +457,6 @@ function SidebarRail({
         )}
       </motion.nav>
 
-      {/* Floating Search Circle below the capsule */}
-      <SearchButton
-        diameter={72}
-        iconSize={24}
-        onOpen={onSearchOpen}
-        surfaceStyle={premiumGlassStyle}
-      />
     </div>
   );
 }
@@ -706,8 +703,8 @@ export function AppShell() {
                 className="app-shell-scrim"
                 initial={{ y: 0, opacity: 1 }}
                 animate={{
-                  y: navState.hidden && !prefersReducedMotion ? 18 : 0,
-                  opacity: navState.hidden ? 0.42 : 1,
+                  y: navState.hidden && !prefersReducedMotion ? 48 : 0,
+                  opacity: navState.hidden ? 0 : 1,
                 }}
                 transition={
                   prefersReducedMotion

--- a/src/app/components/shared/app-shell.tsx
+++ b/src/app/components/shared/app-shell.tsx
@@ -334,15 +334,15 @@ function BottomTabBar({
 }) {
   const { cms } = useCms();
   const prefersReducedMotion = useReducedMotion();
-  const { hidden } = navState;
+  const { hidden, scrolled } = navState;
   return (
     <motion.div
-      className="app-shell-dock"
+      className={`app-shell-dock${scrolled ? " app-shell-dock--scrolled" : ""}`}
       initial={{ y: 0, scale: 1, opacity: 1 }}
       animate={{
-        y: hidden && !prefersReducedMotion ? 92 : 0,
-        scale: hidden && !prefersReducedMotion ? 0.96 : 1,
-        opacity: hidden ? 0 : 1,
+        y: hidden && !prefersReducedMotion ? 16 : 0,
+        scale: hidden && !prefersReducedMotion ? 0.985 : scrolled ? 0.99 : 1,
+        opacity: hidden ? 0.88 : 1,
       }}
       transition={
         prefersReducedMotion
@@ -706,8 +706,8 @@ export function AppShell() {
                 className="app-shell-scrim"
                 initial={{ y: 0, opacity: 1 }}
                 animate={{
-                  y: navState.hidden && !prefersReducedMotion ? 40 : 0,
-                  opacity: navState.hidden ? 0 : 1,
+                  y: navState.hidden && !prefersReducedMotion ? 18 : 0,
+                  opacity: navState.hidden ? 0.42 : 1,
                 }}
                 transition={
                   prefersReducedMotion

--- a/src/app/components/shared/search-overlay.tsx
+++ b/src/app/components/shared/search-overlay.tsx
@@ -433,13 +433,6 @@ export function SearchOverlay({
             transition={{ type: "spring", stiffness: 450, damping: 28 }}
             className={`search-overlay-x__panel${isMobile ? " search-overlay-x__panel--mobile" : ""}`}
           >
-            {/* Drag Handle per Mobile */}
-            {isMobile && (
-              <div className="search-overlay-x__drag-wrap">
-                <div className="search-overlay-x__drag-handle" />
-              </div>
-            )}
-
             {/* Search input row */}
             <div className="search-overlay-x__input-row">
               {/* Icona lente statica a sinistra */}

--- a/src/app/components/shared/vulcan-hero.tsx
+++ b/src/app/components/shared/vulcan-hero.tsx
@@ -78,7 +78,6 @@ export function VulcanHero({
         <VulcanMark
           size={markSize}
           variant={logoVariant}
-          gradient
           glow
           decorative
         />

--- a/src/app/data/equipment-data.ts
+++ b/src/app/data/equipment-data.ts
@@ -76,6 +76,15 @@ export type SurfaceType =
   | "blue_steel_pan"
   | "oven_rack";
 
+export type OvenHeatProfile =
+  | "static_top_bottom"
+  | "top_grill"
+  | "bottom_boost"
+  | "fan_assisted"
+  | "gas_bottom"
+  | "gas_rear"
+  | "wood_side_flame";
+
 interface SurfaceOption {
   id: SurfaceType;
   label: string;
@@ -206,6 +215,7 @@ export interface EquipmentState {
   mixer_level: MixerLevel | null;
   surfaces: SurfaceType[];
   tools: string[];
+  oven_heat_profile?: OvenHeatProfile;
 }
 
 export const DEFAULT_EQUIPMENT: EquipmentState = {
@@ -217,6 +227,7 @@ export const DEFAULT_EQUIPMENT: EquipmentState = {
   mixer_level: null,
   surfaces: [],
   tools: [],
+  oven_heat_profile: "static_top_bottom",
 };
 
 /** Derive legacy booleans from advanced state */

--- a/src/app/domain/pizza-engine.ts
+++ b/src/app/domain/pizza-engine.ts
@@ -282,6 +282,15 @@ export interface UserConstraints {
   mixer_type?: string | null;
   /** Advanced equipment — baking surfaces from profile */
   surfaces?: string[];
+  /** Advanced oven heat profile — resistances/burner layout from profile */
+  oven_heat_profile?:
+    | "static_top_bottom"
+    | "top_grill"
+    | "bottom_boost"
+    | "fan_assisted"
+    | "gas_bottom"
+    | "gas_rear"
+    | "wood_side_flame";
 }
 
 /** Engine message: key-based for i18n, fallback for backward compat */
@@ -1738,6 +1747,7 @@ export function generateRecipe(
       hasMixer: constraints.has_mixer,
       ovenType: constraints.oven_type,
       surfaces: constraints.surfaces,
+      ovenHeatProfile: constraints.oven_heat_profile,
     },
   );
 
@@ -2298,6 +2308,7 @@ interface EquipmentContext {
   hasMixer?: boolean;
   ovenType?: OvenType;
   surfaces?: string[];
+  ovenHeatProfile?: UserConstraints["oven_heat_profile"];
 }
 
 interface KneadGuidance {
@@ -2374,6 +2385,21 @@ function ovenBakeSetup(eq: EquipmentContext | undefined, _ovenTemp: number): str
   const hasStone = (eq?.surfaces ?? []).some((s) =>
     ["refractory_brick", "cordierite_stone", "steel_plate"].includes(s),
   );
+  if (eq?.ovenHeatProfile === "top_grill") {
+    return ` Grill/resistenza superiore forte: preriscalda con ${hasStone ? "pietra o acciaio" : "ripiano"} medio-alto, poi passa al grill solo negli ultimi 45-75s per colorare il cornicione.`;
+  }
+  if (eq?.ovenHeatProfile === "bottom_boost") {
+    return " Resistenza inferiore dominante: cuoci nella parte bassa per spinta di base, poi alza di un livello se il top resta pallido.";
+  }
+  if (eq?.ovenHeatProfile === "fan_assisted") {
+    return " Ventilato: usa una temperatura leggermente piu bassa se il bordo asciuga, ruota a meta cottura e proteggi i topping delicati.";
+  }
+  if (eq?.ovenHeatProfile === "gas_rear") {
+    return " Bruciatore posteriore: tieni la pizza verso il centro e ruotala spesso di piccoli angoli per evitare un lato bruciato.";
+  }
+  if (eq?.ovenHeatProfile === "wood_side_flame") {
+    return " Fiamma laterale viva: inforna sul lato opposto alla fiamma e ruota ogni 20-30s per colorare in modo uniforme.";
+  }
   switch (eq?.ovenType) {
     case "wood":
       return " Forno a legna: platea pulita, fiamma viva sulla cupola. Inforna vicino alla bocca e ruota di 180° dopo 30-40s per leopardare uniformemente.";
@@ -2814,6 +2840,12 @@ function generateTips(
   if (style.crust_type === "leopard_soft") {
     tips.push(
       "Per la leopardatura: il forno deve essere ben caldo e la pizza deve toccare direttamente la superficie calda.",
+    );
+  }
+
+  if (constraints.oven_heat_profile === "gas_rear" || constraints.oven_heat_profile === "wood_side_flame") {
+    tips.push(
+      "La sorgente di calore e laterale/posteriore: prepara la pala per ruotare spesso la pizza, non aspettare che un lato sia gia scuro.",
     );
   }
 

--- a/src/app/features/cms/cms-context.tsx
+++ b/src/app/features/cms/cms-context.tsx
@@ -351,6 +351,9 @@ interface CmsProfile {
   favoriteRemoveAria: string;
   savedRecipesTitle: string;
   savedRecipesSubtitle: string;
+  savedRecipesEmptyTitle: string;
+  savedRecipesEmptyBody: string;
+  savedRecipesEmptyCta: string;
   savedRecipeRemove: string;
   savedRecipeRemoveAria: string;
   // Sections
@@ -1432,7 +1435,7 @@ export const CMS_DEFAULTS: CmsContent = {
     tabRecipe: "Ricetta",
     tabRecipeTailored: "Ricetta su misura",
     recipeCanonical: "Ricetta canonica",
-    recipeCanonicalEyebrow: "Canonica",
+    recipeCanonicalEyebrow: "Originale",
     preCookTitle: "Prima di accendere il forno",
     preCookBody:
       "Questa è ancora la ricetta originale. Puoi partire così, oppure adattarla al tuo forno e ai tuoi tempi prima di iniziare la pizzata.",
@@ -1472,7 +1475,7 @@ export const CMS_DEFAULTS: CmsContent = {
     ceilingOvenWall:
       "Il forno ti ferma a {ceiling}/100: niente leopardatura, ma una buona pizza sì.",
     ceilingNeeds: "Per arrivare a {ceiling}/100 ti serve: {needs}.",
-    ceilingNeedsAtCeiling: "Questa versione assume: {needs}.",
+    ceilingNeedsAtCeiling: "Per questa versione serve: {needs}.",
     ceilingOptimize: "Puoi portarla a {ceiling}/100 ottimizzando — hai già tutto.",
     ceilingCanonicalOk: "Anche la ricetta canonica resta fattibile col tuo setup.",
     ceilingCompromise:
@@ -2114,6 +2117,9 @@ export const CMS_DEFAULTS: CmsContent = {
     favoriteRemoveAria: "Rimuovi {name} dai preferiti",
     savedRecipesTitle: "Le tue ricette salvate",
     savedRecipesSubtitle: "Le versioni su misura che hai messo da parte",
+    savedRecipesEmptyTitle: "Nessuna ricetta salvata",
+    savedRecipesEmptyBody: "Le versioni su misura che salverai compariranno qui.",
+    savedRecipesEmptyCta: "Esplora gli stili",
     savedRecipeRemove: "Rimuovi dal ricettario",
     savedRecipeRemoveAria: "Rimuovi {name} dal ricettario",
     ovenTitle: "Il tuo forno",

--- a/src/app/features/cms/i18n.ts
+++ b/src/app/features/cms/i18n.ts
@@ -15,9 +15,11 @@ import type { CmsUiStrings } from "./cms-context";
 /** Simple template interpolation: replaces {key} placeholders */
 export function t(template: string | undefined, vars: Record<string, string | number>): string {
   if (!template) return "";
-  return template.replace(/\{(\w+)\}/g, (_, key) =>
+  const interpolated = template.replace(/\{(\w+)\}/g, (_, key) =>
     vars[key] !== undefined ? String(vars[key]) : `{${key}}`,
   );
+  // Template e valore interpolato possono entrambi dichiarare una stima.
+  return interpolated.replace(/~\s*~+/g, "~");
 }
 
 export type UnitSystem = "metric" | "imperial";

--- a/src/app/features/cms/locales/de.ts
+++ b/src/app/features/cms/locales/de.ts
@@ -933,6 +933,9 @@ export const DE_LOCALE: CmsContent = {
     favoriteRemoveAria: "{name} aus Favoriten entfernen",
     savedRecipesTitle: "Deine gespeicherten Rezepte",
     savedRecipesSubtitle: "Die maßgeschneiderten Versionen, die du gespeichert hast",
+    savedRecipesEmptyTitle: "Noch keine gespeicherten Rezepte",
+    savedRecipesEmptyBody: "Die Versionen, die du speicherst, erscheinen hier.",
+    savedRecipesEmptyCta: "Stile entdecken",
     savedRecipeRemove: "Aus dem Rezeptbuch entfernen",
     savedRecipeRemoveAria: "{name} aus dem Rezeptbuch entfernen",
     ovenTitle: "Dein Ofen",
@@ -1277,6 +1280,7 @@ export const DE_LOCALE: CmsContent = {
     tabRecipe: "Rezept",
     tabRecipeTailored: "Rezept nach Ma\u00DF",
     recipeCanonical: "Kanonisches Rezept",
+    recipeCanonicalEyebrow: "Original",
     preCookTitle: "Bevor du den Ofen anheizt",
     preCookBody:
       "Dies ist noch das Originalrezept. Du kannst so starten oder es vorher an deinen Ofen und deine Zeiten anpassen.",

--- a/src/app/features/cms/locales/en.ts
+++ b/src/app/features/cms/locales/en.ts
@@ -397,7 +397,7 @@ export const EN_LOCALE: CmsContent = {
     tabRecipe: "Recipe",
     tabRecipeTailored: "Tailored recipe",
     recipeCanonical: "Canonical recipe",
-    recipeCanonicalEyebrow: "Canonical",
+    recipeCanonicalEyebrow: "Original",
     preCookTitle: "Before you fire up the oven",
     preCookBody:
       "This is still the original recipe. You can start as is, or adapt it to your oven and your schedule before the bake.",
@@ -1138,6 +1138,9 @@ export const EN_LOCALE: CmsContent = {
     favoriteRemoveAria: "Remove {name} from favourites",
     savedRecipesTitle: "Your saved recipes",
     savedRecipesSubtitle: "The tailored versions you set aside",
+    savedRecipesEmptyTitle: "No saved recipes yet",
+    savedRecipesEmptyBody: "The tailored versions you save will appear here.",
+    savedRecipesEmptyCta: "Explore styles",
     savedRecipeRemove: "Remove from recipe book",
     savedRecipeRemoveAria: "Remove {name} from recipe book",
     ovenTitle: "Your oven",

--- a/src/app/features/cms/locales/es.ts
+++ b/src/app/features/cms/locales/es.ts
@@ -939,6 +939,9 @@ export const ES_LOCALE: CmsContent = {
     favoriteRemoveAria: "Quitar {name} de favoritos",
     savedRecipesTitle: "Tus recetas guardadas",
     savedRecipesSubtitle: "Las versiones a medida que guardaste",
+    savedRecipesEmptyTitle: "Aún no has guardado recetas",
+    savedRecipesEmptyBody: "Las versiones a medida que guardes aparecerán aquí.",
+    savedRecipesEmptyCta: "Explorar estilos",
     savedRecipeRemove: "Quitar del recetario",
     savedRecipeRemoveAria: "Quitar {name} del recetario",
     ovenTitle: "Tu horno",
@@ -1276,6 +1279,7 @@ export const ES_LOCALE: CmsContent = {
     hintLimitMaxLabel: "límite máx",
   },
   cooking: {
+    recipeCanonicalEyebrow: "Original",
     glossaryPreferment: "Biga y prefermentos",
     glossaryBulk: "Fermentación en bloque",
     glossaryProof: "Fermentación final (appretto)",

--- a/src/app/features/cms/locales/fr.ts
+++ b/src/app/features/cms/locales/fr.ts
@@ -938,6 +938,9 @@ export const FR_LOCALE: CmsContent = {
     favoriteRemoveAria: "Retirer {name} des favoris",
     savedRecipesTitle: "Vos recettes enregistrées",
     savedRecipesSubtitle: "Les versions sur mesure que vous avez gardées",
+    savedRecipesEmptyTitle: "Aucune recette enregistrée",
+    savedRecipesEmptyBody: "Les versions sur mesure que vous garderez apparaîtront ici.",
+    savedRecipesEmptyCta: "Explorer les styles",
     savedRecipeRemove: "Retirer du carnet",
     savedRecipeRemoveAria: "Retirer {name} du carnet",
     ovenTitle: "Votre four",
@@ -1282,6 +1285,7 @@ export const FR_LOCALE: CmsContent = {
     hintLimitMaxLabel: "limite max",
   },
   cooking: {
+    recipeCanonicalEyebrow: "Originale",
     glossaryPreferment: "Biga et pré-ferments",
     glossaryBulk: "Fermentation en masse",
     glossaryProof: "Apprêt",

--- a/src/app/features/cms/locales/ja.ts
+++ b/src/app/features/cms/locales/ja.ts
@@ -1013,6 +1013,9 @@ export const JA_LOCALE: CmsContent = {
     favoriteRemoveAria: "{name}をお気に入りから削除",
     savedRecipesTitle: "保存したレシピ",
     savedRecipesSubtitle: "あなた好みに調整したバージョン",
+    savedRecipesEmptyTitle: "保存したレシピはまだありません",
+    savedRecipesEmptyBody: "保存したレシピはここに表示されます。",
+    savedRecipesEmptyCta: "スタイルを見る",
     savedRecipeRemove: "レシピ帳から削除",
     savedRecipeRemoveAria: "{name}をレシピ帳から削除",
     ovenTitle:
@@ -1411,6 +1414,7 @@ export const JA_LOCALE: CmsContent = {
     tabRecipe: "\u30EC\u30B7\u30D4",
     tabRecipeTailored: "\u3042\u306A\u305F\u7528\u306E\u30EC\u30B7\u30D4",
     recipeCanonical: "\u57FA\u672C\u30EC\u30B7\u30D4",
+    recipeCanonicalEyebrow: "\u30AA\u30EA\u30B8\u30CA\u30EB",
     preCookTitle: "\u30AA\u30FC\u30D6\u30F3\u3092\u6E29\u3081\u308B\u524D\u306B",
     preCookBody:
       "\u3053\u308C\u306F\u307E\u3060\u30AA\u30EA\u30B8\u30CA\u30EB\u306E\u30EC\u30B7\u30D4\u3067\u3059\u3002\u3053\u306E\u307E\u307E\u59CB\u3081\u308B\u3053\u3068\u3082\u3001\u5148\u306B\u30AA\u30FC\u30D6\u30F3\u3084\u6642\u9593\u306B\u5408\u308F\u305B\u3066\u8ABF\u6574\u3059\u308B\u3053\u3068\u3082\u3067\u304D\u307E\u3059\u3002",

--- a/src/app/features/cms/locales/pt.ts
+++ b/src/app/features/cms/locales/pt.ts
@@ -934,6 +934,9 @@ export const PT_LOCALE: CmsContent = {
     favoriteRemoveAria: "Remover {name} dos favoritos",
     savedRecipesTitle: "Suas receitas salvas",
     savedRecipesSubtitle: "As versões sob medida que você guardou",
+    savedRecipesEmptyTitle: "Nenhuma receita salva ainda",
+    savedRecipesEmptyBody: "As versões sob medida que você salvar aparecerão aqui.",
+    savedRecipesEmptyCta: "Explorar estilos",
     savedRecipeRemove: "Remover do livro de receitas",
     savedRecipeRemoveAria: "Remover {name} do livro de receitas",
     ovenTitle: "Seu forno",
@@ -1273,6 +1276,7 @@ export const PT_LOCALE: CmsContent = {
     hintLimitMaxLabel: "limite máx",
   },
   cooking: {
+    recipeCanonicalEyebrow: "Original",
     glossaryPreferment: "Biga e prefermentos",
     glossaryBulk: "Fermentação em bloco",
     glossaryProof: "Fermentação final (appretto)",

--- a/src/app/features/recipe/ingredients-section.tsx
+++ b/src/app/features/recipe/ingredients-section.tsx
@@ -2,7 +2,7 @@
  * Stepper panetti, lista ingredienti (baker's % in nerd), scorporo
  * pre-fermento, Regola 55 e blocchi scienza PizzaNerd. */
 
-import { Check, Copy, HelpCircle } from "lucide-react";
+import { HelpCircle } from "lucide-react";
 import { motion } from "motion/react";
 import type { Dispatch, SetStateAction } from "react";
 import { useCms } from "../cms/cms-context";
@@ -35,8 +35,6 @@ interface IngredientsSectionProps {
   servingUnit: ReturnType<typeof getServingUnit>;
   panSizeLabel: string | null;
   updateBalls: (n: number) => void;
-  copiedIng: boolean;
-  handleCopyIngredients: () => void;
   showRule55Tip: boolean;
   setShowRule55Tip: Dispatch<SetStateAction<boolean>>;
   rule55Description: string;
@@ -50,8 +48,6 @@ export function IngredientsSection({
   servingUnit,
   panSizeLabel,
   updateBalls,
-  copiedIng,
-  handleCopyIngredients,
   showRule55Tip,
   setShowRule55Tip,
   rule55Description,
@@ -65,13 +61,12 @@ export function IngredientsSection({
     `${new Intl.NumberFormat(bcp47, { maximumFractionDigits: maxDecimals }).format(
       (grams / recipe.flour_g) * 100,
     )}%`;
-  const stagedAmount = (amount: string, stage: string) =>
-    recipe.has_pre_ferment ? (
-      <>
-        <span className="bits-ing-row__amount-value">{amount}</span>
-        <span className="bits-ing-row__amount-note">{stage}</span>
-      </>
-    ) : amount;
+  const flourUseLabel = (() => {
+    if (recipe.flour_w >= 330) return "Manitoba o tipo 0 molto forte";
+    if (recipe.flour_w >= 280) return "Tipo 0/00 forte per pizza";
+    if (recipe.flour_w >= 220) return "Tipo 0 media forza";
+    return "Tipo 00 debole/media";
+  })();
   return (
     <>
       {/* ── Ingredients + panetti stepper ── */}
@@ -82,17 +77,6 @@ export function IngredientsSection({
           </h3>
           {/* Visore di sezione — come "Perfetti per te" */}
           <div className="ingredients-header__divider" />
-          <button
-            onClick={handleCopyIngredients}
-            className="type-data-field ingredients-header__copy"
-          >
-            {copiedIng ? (
-              <Check size={14} className="ingredients-header__copy-icon" />
-            ) : (
-              <Copy size={14} />
-            )}
-            {copiedIng ? ui.copied : ui.copy}
-          </button>
         </div>
 
         <div className="ingredients-servings">
@@ -155,17 +139,17 @@ export function IngredientsSection({
                 : simple
                   ? (
                       <>
-                        {flourStrengthLabel(recipe.flour_w, cms)} ·{" "}
+                        {flourUseLabel} · {flourStrengthLabel(recipe.flour_w, cms)} ·{" "}
                         <GlossaryWLink w={recipe.flour_w} />
                       </>
                     )
                   : (
                       <>
-                        <GlossaryWLink w={recipe.flour_w} /> · P/L {recipe.flour_pl}
+                        {flourUseLabel} · <GlossaryWLink w={recipe.flour_w} /> · P/L {recipe.flour_pl}
                       </>
                     )
             }
-            amount={stagedAmount(gramsApprox(recipe.flour_g, fmt), "totale")}
+            amount={gramsApprox(recipe.flour_g, fmt)}
           />
           {recipe.flour_blend && recipe.flour_blend.length > 0 && (
             /* VPL-B2: breakdown del mix risolto. Ogni farina di frumento mostra la
@@ -225,7 +209,7 @@ export function IngredientsSection({
                 )}
               </>
             }
-            amount={stagedAmount(gramsApprox(recipe.water_g, fmt), "totale")}
+            amount={gramsApprox(recipe.water_g, fmt)}
           />
           {recipe.water_temp_c != null && showRule55Tip && (
             <motion.div
@@ -262,7 +246,7 @@ export function IngredientsSection({
           <IngRow
             name={ui.salt}
             detail={isNerd ? bakerPct(recipe.salt_g) : undefined}
-            amount={stagedAmount(fmt.grams(recipe.salt_g), "impasto finale")}
+            amount={fmt.grams(recipe.salt_g)}
           />
           {recipe.yeast_g > 0 && (
             <IngRow
@@ -273,21 +257,21 @@ export function IngredientsSection({
               ]
                 .filter(Boolean)
                 .join(" · ")}
-              amount={stagedAmount(fmt.grams(recipe.yeast_g), "pre-fermento")}
+              amount={fmt.grams(recipe.yeast_g)}
             />
           )}
           {recipe.fat_g > 0 && (
             <IngRow
               name={recipe.fat_label || ui.oilEvo}
               detail={isNerd ? bakerPct(recipe.fat_g) : undefined}
-              amount={stagedAmount(fmt.grams(recipe.fat_g), "impasto finale")}
+              amount={fmt.grams(recipe.fat_g)}
             />
           )}
           {recipe.sugar_g > 0 && (
             <IngRow
               name={ui.sugar}
               detail={isNerd ? bakerPct(recipe.sugar_g) : undefined}
-              amount={stagedAmount(fmt.grams(recipe.sugar_g), "impasto finale")}
+              amount={fmt.grams(recipe.sugar_g)}
             />
           )}
         </div>
@@ -341,8 +325,8 @@ export function IngredientsSection({
           );
         })()}
         <div className="type-numeric ingredients-total">
-          {recipe.dough_balls} × {fmt.grams(recipe.ball_weight_g)} ={" "}
-          {fmt.grams(recipe.total_dough_g)} {ui.totalDough}
+          <span className="ingredients-total__amount">{fmt.grams(recipe.total_dough_g)}</span>
+          <span className="ingredients-total__label">{ui.totalDough}</span>
         </div>
 
         {/* Regola 55: da round 7 vive SOLO come tip della riga Acqua. */}

--- a/src/app/features/recipe/ingredients-section.tsx
+++ b/src/app/features/recipe/ingredients-section.tsx
@@ -65,6 +65,13 @@ export function IngredientsSection({
     `${new Intl.NumberFormat(bcp47, { maximumFractionDigits: maxDecimals }).format(
       (grams / recipe.flour_g) * 100,
     )}%`;
+  const stagedAmount = (amount: string, stage: string) =>
+    recipe.has_pre_ferment ? (
+      <>
+        <span className="bits-ing-row__amount-value">{amount}</span>
+        <span className="bits-ing-row__amount-note">{stage}</span>
+      </>
+    ) : amount;
   return (
     <>
       {/* ── Ingredients + panetti stepper ── */}
@@ -158,7 +165,7 @@ export function IngredientsSection({
                       </>
                     )
             }
-            amount={gramsApprox(recipe.flour_g, fmt)}
+            amount={stagedAmount(gramsApprox(recipe.flour_g, fmt), "totale")}
           />
           {recipe.flour_blend && recipe.flour_blend.length > 0 && (
             /* VPL-B2: breakdown del mix risolto. Ogni farina di frumento mostra la
@@ -218,7 +225,7 @@ export function IngredientsSection({
                 )}
               </>
             }
-            amount={gramsApprox(recipe.water_g, fmt)}
+            amount={stagedAmount(gramsApprox(recipe.water_g, fmt), "totale")}
           />
           {recipe.water_temp_c != null && showRule55Tip && (
             <motion.div
@@ -255,7 +262,7 @@ export function IngredientsSection({
           <IngRow
             name={ui.salt}
             detail={isNerd ? bakerPct(recipe.salt_g) : undefined}
-            amount={fmt.grams(recipe.salt_g)}
+            amount={stagedAmount(fmt.grams(recipe.salt_g), "impasto finale")}
           />
           {recipe.yeast_g > 0 && (
             <IngRow
@@ -266,21 +273,21 @@ export function IngredientsSection({
               ]
                 .filter(Boolean)
                 .join(" · ")}
-              amount={fmt.grams(recipe.yeast_g)}
+              amount={stagedAmount(fmt.grams(recipe.yeast_g), "pre-fermento")}
             />
           )}
           {recipe.fat_g > 0 && (
             <IngRow
               name={recipe.fat_label || ui.oilEvo}
               detail={isNerd ? bakerPct(recipe.fat_g) : undefined}
-              amount={fmt.grams(recipe.fat_g)}
+              amount={stagedAmount(fmt.grams(recipe.fat_g), "impasto finale")}
             />
           )}
           {recipe.sugar_g > 0 && (
             <IngRow
               name={ui.sugar}
               detail={isNerd ? bakerPct(recipe.sugar_g) : undefined}
-              amount={fmt.grams(recipe.sugar_g)}
+              amount={stagedAmount(fmt.grams(recipe.sugar_g), "impasto finale")}
             />
           )}
         </div>

--- a/src/app/features/recipe/interpretation-narrative-card.tsx
+++ b/src/app/features/recipe/interpretation-narrative-card.tsx
@@ -71,13 +71,13 @@ export function InterpretationSwitcher({
   );
   const hiddenCount = interpretations.filter((it) => !shownIds.has(it.id)).length;
 
-  /* Niente etichetta (nota Matteo): la riga si spiega da sola perché UNA voce
-     è SEMPRE selezionata. Stato attivo = modifier CSS, non style inline. */
-
   return (
     <div data-region="filters">
       {/* "Vedi tutte" resta SEMPRE in vista (fuori dallo scroller delle chip). */}
       <div className="interpretation-switcher">
+        <span className="interpretation-switcher__label">
+          Versione
+        </span>
         <div
           className="interpretation-switcher__scroll"
           role="group"

--- a/src/app/features/recipe/procedure-hero.tsx
+++ b/src/app/features/recipe/procedure-hero.tsx
@@ -3,10 +3,11 @@
  * "pronto per il pasto" e Timeline comoda. Stato e handler restano in
  * RecipeOutput (gli orari guidano anche la timeline): qui arrivano via props. */
 
-import { CalendarRange, Minus, Plus } from "lucide-react";
+import { CalendarRange, Clock3, Minus, Plus } from "lucide-react";
 import type {
   ChangeEvent,
   Dispatch,
+  FocusEvent,
   MutableRefObject,
   SetStateAction,
 } from "react";
@@ -22,6 +23,11 @@ import {
   shiftQuarter,
 } from "./recipe-output-format";
 
+function localDateTimeValue(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
 interface ProcedureHeroControlsProps {
   startTime: Date;
   setStartTime: Dispatch<SetStateAction<Date>>;
@@ -32,8 +38,8 @@ interface ProcedureHeroControlsProps {
   setEditingTime: Dispatch<SetStateAction<boolean>>;
   editingEndTime: boolean;
   setEditingEndTime: Dispatch<SetStateAction<boolean>>;
-  handleTimeInput: (e: ChangeEvent<HTMLInputElement>) => void;
-  handleEndTimeInput: (e: ChangeEvent<HTMLInputElement>) => void;
+  handleTimeInput: (e: ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>) => void;
+  handleEndTimeInput: (e: ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>) => void;
   mealSlots: (TimeSlot & { idealStart: Date; isFeasible: boolean })[];
   comfortToggled: boolean;
   setComfortToggled: Dispatch<SetStateAction<boolean>>;
@@ -102,14 +108,17 @@ export function ProcedureHeroControls({
             </button>
             {editingTime ? (
               <input
-                type="time"
+                type="datetime-local"
                 autoFocus
-                defaultValue={fmt.clockTime(startTime)}
+                defaultValue={localDateTimeValue(startTime)}
+                step={900}
                 onBlur={handleTimeInput}
+                onChange={handleTimeInput}
                 onKeyDown={(e) => {
                   if (e.key === "Enter")
                     (e.target as HTMLInputElement).blur();
                 }}
+                aria-label={ui.startTime}
                 className="procedure-hero__time-input type-numeric"
               />
             ) : (
@@ -133,6 +142,14 @@ export function ProcedureHeroControls({
               <Plus size={13} />
             </button>
           </div>
+          <button
+            type="button"
+            onClick={() => setEditingTime(true)}
+            className="procedure-hero__native-picker"
+          >
+            <Clock3 size={13} aria-hidden="true" />
+            Modifica data e ora
+          </button>
         </div>
 
         <div className="procedure-hero__time">
@@ -149,14 +166,17 @@ export function ProcedureHeroControls({
             </button>
             {editingEndTime ? (
               <input
-                type="time"
+                type="datetime-local"
                 autoFocus
-                defaultValue={fmt.clockTime(endTime)}
+                defaultValue={localDateTimeValue(endTime)}
+                step={900}
                 onBlur={handleEndTimeInput}
+                onChange={handleEndTimeInput}
                 onKeyDown={(e) => {
                   if (e.key === "Enter")
                     (e.target as HTMLInputElement).blur();
                 }}
+                aria-label={ui.endTime}
                 className="procedure-hero__time-input type-numeric"
               />
             ) : (
@@ -165,7 +185,7 @@ export function ProcedureHeroControls({
                 className="procedure-hero__time-display type-numeric"
               >
                 <span className="procedure-hero__time-value">
-                  {hasFlexiblePhases ? "~" : ""}
+                  {hasFlexiblePhases ? "ca. " : ""}
                   {fmt.clockTime(endTime)}
                 </span>
                 <span className="procedure-hero__time-suffix type-data-sm">
@@ -181,6 +201,14 @@ export function ProcedureHeroControls({
               <Plus size={13} />
             </button>
           </div>
+          <button
+            type="button"
+            onClick={() => setEditingEndTime(true)}
+            className="procedure-hero__native-picker"
+          >
+            <Clock3 size={13} aria-hidden="true" />
+            Modifica data e ora
+          </button>
         </div>
       </div>
 

--- a/src/app/features/recipe/procedure-hero.tsx
+++ b/src/app/features/recipe/procedure-hero.tsx
@@ -15,7 +15,6 @@ import { createFormatter } from "../cms/i18n";
 import { Surface, Switch } from "../../components/ds/index";
 import type { TimeSlot } from "../../domain/pizza-engine";
 import {
-  dayOffset,
   daySuffix,
   engineMessage,
   optimizeComfort,
@@ -66,12 +65,8 @@ export function ProcedureHeroControls({
   const ui = cms.ui;
   const fmt = createFormatter(ui, bcp47);
 
-  const startSuffixClass = dayOffset(new Date(), startTime) > 0
-    ? "procedure-hero__time-suffix type-data-sm"
-    : "procedure-hero__time-suffix procedure-hero__time-suffix--hidden type-data-sm";
-  const endSuffixClass = dayOffset(new Date(), endTime) > 0
-    ? "procedure-hero__time-suffix type-data-sm"
-    : "procedure-hero__time-suffix procedure-hero__time-suffix--hidden type-data-sm";
+  const startDayLabel = daySuffix(new Date(), startTime, cms.cooking).trim() || "oggi";
+  const endDayLabel = daySuffix(new Date(), endTime, cms.cooking).trim() || "oggi";
 
   const comfortDescClass = comfortToggled
     ? "procedure-hero__comfort-desc procedure-hero__comfort-desc--success type-data-sm"
@@ -125,8 +120,8 @@ export function ProcedureHeroControls({
                 <span className="procedure-hero__time-value">
                   {fmt.clockTime(startTime)}
                 </span>
-                <span className={startSuffixClass}>
-                  {daySuffix(new Date(), startTime, cms.cooking).trim() || " "}
+                <span className="procedure-hero__time-suffix type-data-sm">
+                  {startDayLabel}
                 </span>
               </button>
             )}
@@ -173,8 +168,8 @@ export function ProcedureHeroControls({
                   {hasFlexiblePhases ? "~" : ""}
                   {fmt.clockTime(endTime)}
                 </span>
-                <span className={endSuffixClass}>
-                  {daySuffix(new Date(), endTime, cms.cooking).trim() || " "}
+                <span className="procedure-hero__time-suffix type-data-sm">
+                  {endDayLabel}
                 </span>
               </button>
             )}
@@ -187,34 +182,6 @@ export function ProcedureHeroControls({
             </button>
           </div>
         </div>
-      </div>
-
-      {/* Start Day Shifter */}
-      <div className="procedure-hero__days">
-        {[
-          { offset: 0, label: "Oggi" },
-          { offset: 1, label: "Domani" },
-          { offset: 2, label: "Dopodomani" },
-        ].map((dayOpt) => {
-          const now = new Date();
-          const currentStartDay = dayOffset(now, startTime);
-          const isSelected = currentStartDay === dayOpt.offset;
-          return (
-            <button
-              key={dayOpt.offset}
-              type="button"
-              onClick={() => {
-                const newStart = new Date(startTime);
-                const targetDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() + dayOpt.offset);
-                newStart.setFullYear(targetDate.getFullYear(), targetDate.getMonth(), targetDate.getDate());
-                setStartTime(roundToQuarter(newStart));
-              }}
-              className={isSelected ? "procedure-hero__day procedure-hero__day--active" : "procedure-hero__day"}
-            >
-              {dayOpt.label}
-            </button>
-          );
-        })}
       </div>
 
       {/* Smart Eating Planner Shortcuts */}

--- a/src/app/features/recipe/procedure-timeline.tsx
+++ b/src/app/features/recipe/procedure-timeline.tsx
@@ -3,7 +3,7 @@
  * flessibili, StepDetails e ToppingSection inline allo step Condimento. */
 
 import { FlaskConical } from "lucide-react";
-import { motion } from "motion/react";
+import { AnimatePresence, motion } from "motion/react";
 import { useCms } from "../cms/cms-context";
 import { createFormatter, t } from "../cms/i18n";
 import { StepIllustration } from "../cooking/step-illustrations";
@@ -194,12 +194,21 @@ export function ProcedureTimeline({
                       {isToppingTimelineStep(step.id) ? cms.cooking.toppingTitle : localizedStep.title}
                     </span>
                     {isToppingTimelineStep(step.id) ? (
-                      <>
+                      <AnimatePresence mode="wait" initial={false}>
+                        <motion.div
+                          key={activeTopping?.id ?? "no-topping"}
+                          className="procedure-timeline-step__topping"
+                          initial={{ opacity: 0, y: 8 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          exit={{ opacity: 0, y: -6 }}
+                          transition={{ type: "spring", stiffness: 420, damping: 32 }}
+                        >
                         <ToppingSection mode="timeline" recipe={recipe} activeTopping={activeTopping} toppingChoices={toppingChoices} allToppingChoices={allToppingChoices} servingUnit={servingUnit} onSelectTopping={onSelectTopping} />
                         <p className="procedure-timeline-step__desc procedure-timeline-step__desc--topping">
                           {localizedStep.description}
                         </p>
-                      </>
+                        </motion.div>
+                      </AnimatePresence>
                     ) : (
                       <p className="procedure-timeline-step__desc">
                         {localizedStep.description}

--- a/src/app/features/recipe/recipe-match-card.tsx
+++ b/src/app/features/recipe/recipe-match-card.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion, useSpring, useTransform } from "motion/react";
-import { Bookmark, BookmarkCheck, Heart, HeartHandshake, HeartPulse, HeartOff, Info, SlidersHorizontal, Sparkles, TriangleAlert } from "lucide-react";
+import { Bookmark, BookmarkCheck, Heart, HeartCrack, HeartHandshake, HeartPulse, HeartOff, Info, SlidersHorizontal, Sparkles, TriangleAlert } from "lucide-react";
 import { SCORE_DIMENSIONS, resolveEngineMsgs, type RecipeScores, type ScoreDimensionKey } from "../../domain/pizza-engine";
 import { useCms } from "../cms/cms-context";
 import { createFormatter, t } from "../cms/i18n";
@@ -270,7 +270,7 @@ export function RecipeMatchCard({
       headroomLine = {
         tone: "accent",
         text: atCeiling
-          ? t(cms.cooking.ceilingNeedsAtCeiling ?? "Questa versione assume: {needs}.", {
+          ? t(cms.cooking.ceilingNeedsAtCeiling ?? "Per questa versione serve: {needs}.", {
               needs: needs.join(", "),
             })
           : t(cms.cooking.ceilingNeeds, { ceiling: ceilingRounded, needs: needs.join(", ") }),
@@ -291,7 +291,7 @@ export function RecipeMatchCard({
     handshake: HeartHandshake,
     heart: Heart,
     pulse: HeartPulse,
-    crack: TriangleAlert,
+    crack: HeartCrack,
     off: HeartOff,
   } as const;
   const MatchIcon = MATCH_ICONS[tone.icon];
@@ -307,7 +307,7 @@ export function RecipeMatchCard({
   return (
     <motion.section
       layout
-      data-region="card"
+      data-region="section"
       className={`match-card ${className}`}
       aria-label={cms.ui.recipeScore}
     >
@@ -325,6 +325,29 @@ export function RecipeMatchCard({
         />
         <span className="match-kicker__label">Match</span>
         <span className="match-kicker__rule" aria-hidden="true" />
+        <button
+          type="button"
+          onClick={() =>
+            setExpanded((v) => {
+              if (v) setExplainKey(null);
+              return !v;
+            })
+          }
+          aria-expanded={expanded}
+          aria-label={
+            expanded
+              ? (cms.cooking.matchDetailsHide ?? "Nascondi")
+              : (cms.cooking.matchDetails ?? "Dettagli")
+          }
+          title={
+            expanded
+              ? (cms.cooking.matchDetailsHide ?? "Nascondi")
+              : (cms.cooking.matchDetails ?? "Dettagli")
+          }
+          className={`match-info-toggle${expanded ? " match-info-toggle--active" : ""}`}
+        >
+          <Info size={16} />
+        </button>
       </div>
 
       {/* Verdetto: numero serifa + tono corsivo, stesso baseline. */}
@@ -364,31 +387,6 @@ export function RecipeMatchCard({
             </motion.span>
           </AnimatePresence>
         </span>
-        {/* I dettagli si aprono da un'iconcina ⓘ accanto al tono (nota
-            Matteo): prossimità massima con ciò che spiega. */}
-        <button
-          type="button"
-          onClick={() =>
-            setExpanded((v) => {
-              if (v) setExplainKey(null);
-              return !v;
-            })
-          }
-          aria-expanded={expanded}
-          aria-label={
-            expanded
-              ? (cms.cooking.matchDetailsHide ?? "Nascondi")
-              : (cms.cooking.matchDetails ?? "Dettagli")
-          }
-          title={
-            expanded
-              ? (cms.cooking.matchDetailsHide ?? "Nascondi")
-              : (cms.cooking.matchDetails ?? "Dettagli")
-          }
-          className={`match-info-toggle${expanded ? " match-info-toggle--active" : ""}`}
-        >
-          <Info size={16} />
-        </button>
       </div>
 
       {/* Avvisi onesti: visibili anche a card chiusa */}

--- a/src/app/features/recipe/recipe-match-card.tsx
+++ b/src/app/features/recipe/recipe-match-card.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion, useSpring, useTransform } from "motion/react";
-import { Bookmark, BookmarkCheck, Heart, HeartCrack, HeartHandshake, HeartPulse, HeartOff, Info, SlidersHorizontal, Sparkles, TriangleAlert } from "lucide-react";
+import { Bookmark, BookmarkCheck, Heart, HeartHandshake, HeartPulse, HeartOff, Info, SlidersHorizontal, Sparkles, TriangleAlert } from "lucide-react";
 import { SCORE_DIMENSIONS, resolveEngineMsgs, type RecipeScores, type ScoreDimensionKey } from "../../domain/pizza-engine";
 import { useCms } from "../cms/cms-context";
 import { createFormatter, t } from "../cms/i18n";
@@ -291,7 +291,7 @@ export function RecipeMatchCard({
     handshake: HeartHandshake,
     heart: Heart,
     pulse: HeartPulse,
-    crack: HeartCrack,
+    crack: TriangleAlert,
     off: HeartOff,
   } as const;
   const MatchIcon = MATCH_ICONS[tone.icon];

--- a/src/app/features/recipe/recipe-output-bits.tsx
+++ b/src/app/features/recipe/recipe-output-bits.tsx
@@ -75,7 +75,7 @@ export function IngRow({
 }: {
   name: string;
   detail?: ReactNode;
-  amount: string;
+  amount: ReactNode;
 }) {
   return (
     <div className="bits-ing-row">
@@ -177,4 +177,3 @@ export function GlossaryWLink({ w }: { w: number }) {
     </>
   );
 }
-

--- a/src/app/features/recipe/recipe-output-format.ts
+++ b/src/app/features/recipe/recipe-output-format.ts
@@ -162,7 +162,9 @@ function clockWithDay(
 
 /** Orario "onesto" (feedback giugno 2026): le fasi flessibili (puntata,
  * appretto, pre-fermento) durano ore — "inizia alle 18:17" è precisione
- * finta. Arrotondiamo ai 15' con prefisso ~; le fasi attive restano esatte. */
+ * finta. Arrotondiamo ai 15' con prefisso ~. Anche le fasi operative derivate
+ * dalla timeline vengono arrotondate ai 5': i minuti esatti restano solo nei
+ * controlli inizio/fine, dove l'utente sta scegliendo l'orario. */
 export function displayStepTime(
   stepId: string,
   date: Date,
@@ -171,7 +173,9 @@ export function displayStepTime(
   copy?: CmsContent["cooking"],
 ): string {
   if (!FLEXIBLE_STEP_IDS.has(stepId)) {
-    return clockWithDay(date, reference, bcp47, copy);
+    const rounded = new Date(Math.round(date.getTime() / 300_000) * 300_000);
+    const prefix = Math.abs(rounded.getTime() - date.getTime()) >= 60_000 ? "≈" : "";
+    return `${prefix}${clockWithDay(rounded, reference, bcp47, copy)}`;
   }
   const rounded = new Date(Math.round(date.getTime() / 900_000) * 900_000);
   return `~${clockWithDay(rounded, reference, bcp47, copy)}`;
@@ -376,13 +380,23 @@ export function yeastPracticalHint(grams: number, type: string, cms: CmsContent 
   return undefined; // madre: pesabile, nessuna nota
 }
 
-/** Unified duration formatter: "15 min" / "1h 30min" / "16h" / "1g 4h" / "2g 3h" */
+function honestDurationMinutes(minutes: number): number {
+  if (minutes <= 0) return 0;
+  if (minutes < 10) return Math.max(1, Math.round(minutes));
+  if (minutes < 180) return Math.max(5, Math.round(minutes / 5) * 5);
+  return Math.max(15, Math.round(minutes / 15) * 15);
+}
+
+/** Unified duration formatter: "15 min" / "1h 30min" / "16h" / "1g 4h" / "2g 3h".
+ * Display only: long timeline blocks are rounded to human increments so the UI
+ * does not imply false minute-level precision for fermentation windows. */
 export function fmtDuration(minutes: number, fmt?: ReturnType<typeof createFormatter>): string {
-  if (minutes <= 0) return "";
-  if (fmt) return fmt.durationMinutes(minutes);
-  if (minutes < 60) return `${minutes} min`;
-  const totalH = Math.floor(minutes / 60);
-  const m = minutes % 60;
+  const roundedMinutes = honestDurationMinutes(minutes);
+  if (roundedMinutes <= 0) return "";
+  if (fmt) return fmt.durationMinutes(roundedMinutes);
+  if (roundedMinutes < 60) return `${roundedMinutes} min`;
+  const totalH = Math.floor(roundedMinutes / 60);
+  const m = roundedMinutes % 60;
   if (totalH < 24) {
     if (m === 0) return `${totalH}h`;
     return `${totalH}h ${m}min`;

--- a/src/app/features/recipe/recipe-output-format.ts
+++ b/src/app/features/recipe/recipe-output-format.ts
@@ -174,11 +174,11 @@ export function displayStepTime(
 ): string {
   if (!FLEXIBLE_STEP_IDS.has(stepId)) {
     const rounded = new Date(Math.round(date.getTime() / 300_000) * 300_000);
-    const prefix = Math.abs(rounded.getTime() - date.getTime()) >= 60_000 ? "≈" : "";
+    const prefix = Math.abs(rounded.getTime() - date.getTime()) >= 60_000 ? "ca. " : "";
     return `${prefix}${clockWithDay(rounded, reference, bcp47, copy)}`;
   }
   const rounded = new Date(Math.round(date.getTime() / 900_000) * 900_000);
-  return `~${clockWithDay(rounded, reference, bcp47, copy)}`;
+  return `ca. ${clockWithDay(rounded, reference, bcp47, copy)}`;
 }
 
 function normalizeTemperatureUnitSuffixes(text: string): string {

--- a/src/app/features/recipe/recipe-output.tsx
+++ b/src/app/features/recipe/recipe-output.tsx
@@ -7,15 +7,14 @@ import { ToppingSection } from "./topping-section";
 import { ProcedureHeroControls } from "./procedure-hero";
 import { IngredientsSection } from "./ingredients-section";
 import { ProcedureTimeline } from "./procedure-timeline";
-import { addMinutes, copyToClipboard, gramsApprox, localizeStep, normalizeMeasureUnitSuffixes, optimizeComfort, roundToQuarter, formatToppingAmountForLocale, getSectionHeader, getServingUnitLabel, getToppingIngredientSectionOrder, toppingSectionLabel } from "./recipe-output-format";
-import type { CmsContent } from "../cms/cms-context";
+import { addMinutes, localizeStep, optimizeComfort, roundToQuarter, getServingUnitLabel, toppingSectionLabel } from "./recipe-output-format";
 import { useCms } from "../cms/cms-context";
 import { createFormatter, t } from "../cms/i18n";
 import { FLEXIBLE_STEP_IDS, useCookSession, type CookSessionStep } from "../cooking/cook-session";
 import type { FlourEntry } from "../../data/flour-database";
-import { GeneratedRecipe, generateTimeSlots, getServingUnit, needsPan, UserConstraints, YEAST_LABELS, type PanConfig } from "../../domain/pizza-engine";
+import { GeneratedRecipe, generateTimeSlots, getServingUnit, needsPan, UserConstraints, type PanConfig } from "../../domain/pizza-engine";
 import { RecipeFeedbackForm } from "./recipe-feedback";
-import { getRecipesByAuthenticity, getToppingForStyle, TOPPING_CONCEPTS, type IngredientSection, type ToppingIngredient } from "../../data/topping-library";
+import { getRecipesByAuthenticity, getToppingForStyle } from "../../data/topping-library";
 import { ConfirmDialog, IconButton } from "../../components/ds/index";
 
 
@@ -87,7 +86,7 @@ export function RecipeOutput({
   hideContextSummary = false,
   recipeControls,
   matchSlot,
-  showFeedback = true,
+  showFeedback = false,
   selectedToppingConcept,
   onSelectTopping,
   onTabChange,
@@ -98,7 +97,6 @@ export function RecipeOutput({
   onRequestPersonalization,
 }: RecipeOutputProps) {
   const reduceMotion = useReducedMotion();
-  const [copiedIng, setCopiedIng] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
@@ -258,13 +256,6 @@ export function RecipeOutput({
   const showNerdToggle = nerdAvailable && !!onNerdModeChange;
   const isNerd = showNerdToggle && !!nerdMode;
 
-  const handleCopyIngredients = () => {
-    const text = formatIngredientsText(recipe, cms, bcp47);
-    copyToClipboard(text, () => {
-      setCopiedIng(true);
-      setTimeout(() => setCopiedIng(false), 2000);
-    });
-  };
   /* ── Timeline comoda (feedback giugno 2026): minuti extra per fase ──
    * Le fasi flessibili possono stirarsi/accorciarsi entro tolleranze: un'ora
    * in più di frigo non cambia la pizza, ma evita la sveglia alle 5. */
@@ -493,24 +484,32 @@ export function RecipeOutput({
 
 
   function handleTimeInput(
-    e: React.ChangeEvent<HTMLInputElement>,
+    e: React.ChangeEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>,
   ) {
-    const [h, m] = e.target.value.split(":").map(Number);
-    if (!isNaN(h) && !isNaN(m)) {
-      const d = new Date(startTime);
-      d.setHours(h, m, 0, 0);
-      setStartTime(d);
-    }
-    setEditingTime(false);
+    const value = e.target.value;
+    if (!value) return;
+    const d = value.includes("T") ? new Date(value) : (() => {
+      const [h, m] = value.split(":").map(Number);
+      const next = new Date(startTime);
+      if (!isNaN(h) && !isNaN(m)) next.setHours(h, m, 0, 0);
+      return next;
+    })();
+    if (!isNaN(d.getTime())) setStartTime(roundToQuarter(d));
+    if (e.type === "blur") setEditingTime(false);
   }
 
   function handleEndTimeInput(
-    e: React.ChangeEvent<HTMLInputElement>,
+    e: React.ChangeEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>,
   ) {
-    const [h, m] = e.target.value.split(":").map(Number);
-    if (!isNaN(h) && !isNaN(m)) {
-      const desired = new Date(startTime);
-      desired.setHours(h, m, 0, 0);
+    const value = e.target.value;
+    if (!value) return;
+    const desired = value.includes("T") ? new Date(value) : (() => {
+      const [h, m] = value.split(":").map(Number);
+      const next = new Date(startTime);
+      if (!isNaN(h) && !isNaN(m)) next.setHours(h, m, 0, 0);
+      return next;
+    })();
+    if (!isNaN(desired.getTime())) {
       // If desired end is before or equal to start, assume next day
       if (desired.getTime() <= startTime.getTime()) {
         desired.setDate(desired.getDate() + 1);
@@ -526,7 +525,7 @@ export function RecipeOutput({
       // Inizio sempre su un quarto d'ora: "parti alle 07:37" è precisione finta.
       setStartTime(roundToQuarter(newStart));
     }
-    setEditingEndTime(false);
+    if (e.type === "blur") setEditingEndTime(false);
   }
 
   const updateBalls = (n: number) => {
@@ -735,8 +734,6 @@ export function RecipeOutput({
         servingUnit={servingUnit}
         panSizeLabel={panSizeLabel}
         updateBalls={updateBalls}
-        copiedIng={copiedIng}
-        handleCopyIngredients={handleCopyIngredients}
         showRule55Tip={showRule55Tip}
         setShowRule55Tip={setShowRule55Tip}
         rule55Description={rule55Description}
@@ -833,63 +830,4 @@ export function RecipeOutput({
 
     </div>
   );
-}
-
-
-function formatIngredientsText(r: GeneratedRecipe, cms: CmsContent, bcp47: string) {
-  const ui = cms.ui;
-  const fmt = createFormatter(ui, bcp47);
-  const yeastName = cms.yeastLabels[r.yeast_type] || YEAST_LABELS[r.yeast_type] || r.yeast_type;
-  const title = t(ui.clipboardTitle, { style: r.style.name });
-  const balls = normalizeMeasureUnitSuffixes(t(ui.clipboardBalls, { n: r.dough_balls, w: fmt.grams(r.ball_weight_g) }));
-  const total = normalizeMeasureUnitSuffixes(t(ui.clipboardTotal, { g: fmt.grams(r.total_dough_g) }));
-  const doughText = `${title}\n${balls}\n\n${ui.flour} W${r.flour_w} · P/L ${r.flour_pl}: ${gramsApprox(r.flour_g, fmt)}\n${ui.water}: ${gramsApprox(r.water_g, fmt)} (${fmt.percent(r.hydration_pct)})\n${ui.salt}: ${fmt.grams(r.salt_g)}${r.yeast_g > 0 ? `\n${yeastName}: ${fmt.grams(r.yeast_g)}` : ""}${r.fat_g > 0 ? `\n${r.fat_label || ui.oilEvo}: ${fmt.grams(r.fat_g)}` : ""}\n\n${total}`;
-
-  const toppingRefId = r.style.default_topping_ref;
-  if (!toppingRefId) return doughText;
-  const topping = getToppingForStyle(toppingRefId, r.style);
-  if (!topping?.ingredients?.length) return doughText;
-
-  const concept = TOPPING_CONCEPTS[topping.concept_ref];
-  const toppingTitle = topping.name ?? concept?.name ?? cms.cooking.toppingTitle;
-
-  const hasSections = topping.ingredients.some((ing) => ing.section !== undefined);
-  let toppingDetailsText = "";
-
-  if (hasSections) {
-    const sectionOrder = getToppingIngredientSectionOrder(topping.ingredients);
-    const grouped: Record<IngredientSection, ToppingIngredient[]> = {
-      ripieno: [],
-      base: [],
-      crosta: [],
-      superficie: [],
-    };
-    topping.ingredients.forEach((ing) => {
-      const sec = ing.section ?? "superficie";
-      grouped[sec].push(ing);
-    });
-
-    const sectionsText: string[] = [];
-    sectionOrder.forEach((sec) => {
-      const list = grouped[sec];
-      if (list.length === 0) return;
-      const header = getSectionHeader(sec, bcp47);
-      const lines = list.map((ing) => {
-        const singleAmount = formatToppingAmountForLocale(ing.amount.value, ing.amount.unit, fmt);
-        const notes = [ing.notes, ing.optional ? ui.pantryOptional : null].filter(Boolean).join(" · ");
-        return `- ${ing.name}: ${singleAmount}${notes ? ` — ${notes}` : ""}`;
-      });
-      sectionsText.push(`[${header}]\n${lines.join("\n")}`);
-    });
-    toppingDetailsText = sectionsText.join("\n\n");
-  } else {
-    const lines = topping.ingredients.map((ing) => {
-      const singleAmount = formatToppingAmountForLocale(ing.amount.value, ing.amount.unit, fmt);
-      const notes = [ing.notes, ing.optional ? ui.pantryOptional : null].filter(Boolean).join(" · ");
-      return `${ing.name}: ${singleAmount}${notes ? ` — ${notes}` : ""}`;
-    });
-    toppingDetailsText = lines.join("\n");
-  }
-
-  return `${doughText}\n\n${cms.cooking.toppingTitle} — ${toppingTitle}\n${toppingDetailsText}\n\n${cms.cooking.toppingAmountsNote}`;
 }

--- a/src/app/features/recipe/recipe-setup-panel.tsx
+++ b/src/app/features/recipe/recipe-setup-panel.tsx
@@ -540,7 +540,7 @@ function MatchSummary({
           return (
             <div key={axis.key} className="setup-match__axis">
               <div className="setup-match__axis-row">
-                <span title={axis.label}>{axis.shortLabel}</span>
+                <span title={axis.label}>{axis.label}</span>
                 <span className="type-numeric">{val}</span>
               </div>
               <div className="setup-match__track">

--- a/src/app/features/recipe/recipe-setup-panel.tsx
+++ b/src/app/features/recipe/recipe-setup-panel.tsx
@@ -359,7 +359,11 @@ export function RecipeSetupPanel({
               </span>
             </div>
             <div className="setup-profile__body">
-              <div className="setup-versions">
+              <div
+                className="setup-versions setup-versions--binary"
+                role="group"
+                aria-label={cmsMessage(cms, "recipeSetup.profileLabel", "Profilo impasto")}
+              >
                 {versions.map((version) => {
                   const active = !activeInterpretationId && activeVersion?.id === version.id;
                   return (
@@ -367,7 +371,7 @@ export function RecipeSetupPanel({
                       key={version.id}
                       type="button"
                       onClick={() => onSelectVersion(version)}
-                      className={active ? "setup-option setup-option--active" : "setup-option"}
+                      className={active ? "setup-option setup-option--binary setup-option--active" : "setup-option setup-option--binary"}
                     >
                       <div className="setup-option__text">
                         <span className="setup-option__name">

--- a/src/app/features/recipe/recipe-stat-strip.tsx
+++ b/src/app/features/recipe/recipe-stat-strip.tsx
@@ -1,4 +1,4 @@
-import { TrendingDown, TrendingUp } from "lucide-react";
+import { ArrowRight, Sparkles } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useCms } from "../cms/cms-context";
 import { createFormatter } from "../cms/i18n";
@@ -32,21 +32,21 @@ export function RecipeStatStrip({
   );
   const hChanged =
     isPersonalized && Math.abs(recipe.hydration_pct - hMid) >= 2
-      ? { dir: recipe.hydration_pct > hMid ? "up" : ("down" as "up" | "down"), canonical: fmt.percent(hMid) }
+      ? { canonical: fmt.percent(hMid) }
       : undefined;
   const fMid = Math.round(
     (recipe.style.dough.fermentation_hours_range[0] + recipe.style.dough.fermentation_hours_range[1]) / 2,
   );
   const fChanged =
     isPersonalized && Math.abs(recipe.fermentation_hours - fMid) >= 2
-      ? { dir: recipe.fermentation_hours > fMid ? "up" : ("down" as "up" | "down"), canonical: fmt.fermentTime(fMid) }
+      ? { canonical: fmt.fermentTime(fMid) }
       : undefined;
   const wMid = Math.round(
     (recipe.style.dough.flour_w_range[0] + recipe.style.dough.flour_w_range[1]) / 2,
   );
   const wChanged =
     isPersonalized && Math.abs(recipe.flour_w - wMid) >= 15
-      ? { dir: recipe.flour_w > wMid ? "up" : ("down" as "up" | "down"), canonical: `W${wMid}` }
+      ? { canonical: `W${wMid}` }
       : undefined;
 
   /* Round 6-7 (note Matteo): in tabella SOLO i valori che cambiano e
@@ -60,7 +60,7 @@ export function RecipeStatStrip({
   const cells: {
     label: string;
     value: string;
-    changed?: { dir: "up" | "down"; canonical: string };
+    changed?: { canonical: string };
   }[] = [
     { label: ui.statHydration, value: fmt.percent(recipe.hydration_pct), changed: hChanged },
     { label: ui.statFlourStrength ?? "Forza farina", value: `${recipe.flour_w} W`, changed: wChanged },
@@ -101,7 +101,7 @@ export function SpecCell({
   label: string;
   value: string;
   index?: number;
-  changed?: { dir: "up" | "down"; canonical: string };
+  changed?: { canonical: string };
   small?: boolean;
   science?: boolean;
 }) {
@@ -126,8 +126,29 @@ export function SpecCell({
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -8 }}
           transition={{ type: "spring", stiffness: 420, damping: 30 }}
-          className="type-numeric stat-strip__value"
+          className={changed ? "type-numeric stat-strip__value stat-strip__value--changed" : "type-numeric stat-strip__value"}
+          title={changed ? `Prima ${changed.canonical} → ottimizzato ${value}` : undefined}
+          aria-label={changed ? `Valore ottimizzato. Prima: ${changed.canonical}. Ora: ${value}` : undefined}
         >
+          {changed && (
+            <>
+              <span className="stat-strip__value-prev">
+                {changed.canonical}
+              </span>
+              <ArrowRight
+                size={small ? 11 : 12}
+                strokeWidth={2.4}
+                className="stat-strip__value-arrow"
+                aria-hidden="true"
+              />
+              <Sparkles
+                size={small ? 11 : 12}
+                strokeWidth={2.4}
+                className="stat-strip__value-star"
+                aria-hidden="true"
+              />
+            </>
+          )}
           <span
             className={
               small
@@ -157,19 +178,6 @@ export function SpecCell({
               }
             >
               {parts.extra}
-            </span>
-          )}
-          {changed && (
-            <span
-              className="stat-strip__value-trend"
-              title={`Su misura per te · canonica ${changed.canonical}`}
-              aria-label={`Valore su misura. Canonica: ${changed.canonical}`}
-            >
-              {changed.dir === "up" ? (
-                <TrendingUp size={small ? 12 : 13} strokeWidth={2.5} />
-              ) : (
-                <TrendingDown size={small ? 12 : 13} strokeWidth={2.5} />
-              )}
             </span>
           )}
         </motion.div>

--- a/src/app/features/recipe/recipe-view.tsx
+++ b/src/app/features/recipe/recipe-view.tsx
@@ -13,7 +13,7 @@
 import { useState, useEffect, useMemo, type ReactNode } from "react";
 import { Link } from "react-router";
 import { AnimatePresence, motion, useMotionValueEvent, useReducedMotion, useScroll, useTransform } from "motion/react";
-import { Check, ChevronLeft, RotateCcw, Share2 } from "lucide-react";
+import { ChevronLeft, RotateCcw } from "lucide-react";
 import { Heading, IconButton } from "../../components/ds/index";
 import { ImageWithFallback } from "../../components/media/ImageWithFallback";
 import { RecipeOutput } from "./recipe-output";
@@ -106,7 +106,6 @@ export function RecipeView({
   matchSlot,
   introExtraSlot,
   recipeControls,
-  shareUrl,
   showStickyHeader = false,
   selectedToppingConcept,
   onSelectTopping,
@@ -144,8 +143,6 @@ export function RecipeView({
     if (dy > 6) setBackHidden(true);
     else if (dy < -6) setBackHidden(false);
   });
-
-  const [linkCopied, setLinkCopied] = useState(false);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -217,26 +214,6 @@ export function RecipeView({
   const resolvedMarginTop = isHeroReduced
     ? (showStickyHeader ? "var(--space-4, 16px)" : "var(--space-20, 80px)")
     : "calc(-1 * var(--space-19, 4.75rem))";
-
-  const handleShare = () => {
-    if (!shareUrl) return;
-    if (navigator.share) {
-      navigator.share({
-        title: `${recipe.style.name} — Vulcan`,
-        url: shareUrl,
-      }).catch(() => {
-        navigator.clipboard.writeText(shareUrl).then(() => {
-          setLinkCopied(true);
-          setTimeout(() => setLinkCopied(false), 2000);
-        });
-      });
-    } else {
-      navigator.clipboard.writeText(shareUrl).then(() => {
-        setLinkCopied(true);
-        setTimeout(() => setLinkCopied(false), 2000);
-      });
-    }
-  };
 
   const heroEyebrow = eyebrow;
   const heroTitle = style.name;
@@ -462,29 +439,9 @@ export function RecipeView({
                     </p>
                   )}
 
-                  {(introExtraSlot || shareUrl) && (
+                  {introExtraSlot && (
                     <div className="recipe-view-utility-row">
                       {introExtraSlot}
-                      {shareUrl && (
-                        <button
-                          type="button"
-                          onClick={handleShare}
-                          className={
-                            linkCopied
-                              ? "recipe-view-share recipe-view-share--copied"
-                              : "recipe-view-share"
-                          }
-                          title={linkCopied ? cms.ui.copied : cms.ui.share}
-                          aria-label={cms.pages.recipeCopyLinkAria}
-                        >
-                          {linkCopied ? (
-                            <Check size={15} strokeWidth={2.5} />
-                          ) : (
-                            <Share2 size={15} />
-                          )}
-                          <span data-slot="label">{linkCopied ? cms.ui.copied : cms.ui.share}</span>
-                        </button>
-                      )}
                     </div>
                   )}
                 </motion.div>
@@ -532,7 +489,6 @@ export function RecipeView({
               hideContextSummary
               selectedToppingConcept={selectedToppingConcept}
               onSelectTopping={onSelectTopping}
-              shareUrl={shareUrl}
               recipeControls={recipeControls}
               selectedFlourId={selectedFlourId}
               onSelectFlour={onSelectFlour}
@@ -563,4 +519,3 @@ export function RecipeView({
     </div>
   );
 }
-

--- a/src/app/features/recipe/recipe-view.tsx
+++ b/src/app/features/recipe/recipe-view.tsx
@@ -10,9 +10,9 @@
  * Il selettore tab (RecipeSectionTabs) qui è finalmente montato: il layer
  * PizzaNerd vive dentro Ricetta/Procedimento quando abilitato dal Profilo. */
 
-import { useState, useEffect, useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 import { Link } from "react-router";
-import { AnimatePresence, motion, useMotionValueEvent, useReducedMotion, useScroll, useTransform } from "motion/react";
+import { AnimatePresence, motion, useScroll, useTransform } from "motion/react";
 import { ChevronLeft, RotateCcw } from "lucide-react";
 import { Heading, IconButton } from "../../components/ds/index";
 import { ImageWithFallback } from "../../components/media/ImageWithFallback";
@@ -128,21 +128,6 @@ export function RecipeView({
   const heroImageScale = useTransform(scrollY, [0, 400], [1.02, 1.15]);
   const heroOverlayOpacity = useTransform(scrollY, [0, 300], [0, 0.65]);
   const cardY = useTransform(scrollY, [0, 400], [0, -20]);
-  const prefersReducedMotion = useReducedMotion();
-
-  /* Il back flottante segue la chrome liquida: si ritira mentre leggi
-     (altrimenti resta sovrapposto ai contenuti), riemerge appena risali. */
-  const [backHidden, setBackHidden] = useState(false);
-  useMotionValueEvent(scrollY, "change", (y) => {
-    const prev = scrollY.getPrevious() ?? y;
-    const dy = y - prev;
-    if (y < 96) {
-      setBackHidden(false);
-      return;
-    }
-    if (dy > 6) setBackHidden(true);
-    else if (dy < -6) setBackHidden(false);
-  });
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -267,11 +252,8 @@ export function RecipeView({
         </header>
       ) : (
         <motion.div
-          className={backHidden ? "recipe-view-back recipe-view-back--hidden" : "recipe-view-back"}
-          animate={{
-            y: backHidden && !prefersReducedMotion ? -72 : 0,
-            opacity: backHidden ? 0 : 1,
-          }}
+          className="recipe-view-back"
+          animate={{ y: 0, opacity: 1 }}
           transition={{ type: "spring", stiffness: 360, damping: 31, mass: 0.72 }}
         >
           {back.to ? (
@@ -279,7 +261,7 @@ export function RecipeView({
               as={Link}
               to={back.to}
               size="lg"
-              variant="ghost"
+              variant="bare"
               className="recipe-view-back__button"
               aria-label={back.label}
               title={back.label}
@@ -291,7 +273,7 @@ export function RecipeView({
               type="button"
               onClick={back.onClick}
               size="lg"
-              variant="ghost"
+              variant="bare"
               className="recipe-view-back__button"
               aria-label={back.label}
               title={back.label}
@@ -426,21 +408,20 @@ export function RecipeView({
                   {/* Round 3 "pulizia": le caratteristiche non sono più 3 chip
                       (scatole che ricalcavano la descrizione) ma UNA riga meta
                       muta — è metadata, non azione. */}
-                  {heroTags.length > 0 && (
-                    <p className="recipe-view-tags">
-                      {heroTags
-                        .map((tag) =>
-                          tag ? tag.charAt(0).toUpperCase() + tag.slice(1) : tag,
-                        )
-                        /* Ogni caratteristica è un'unità: va a capo solo sui
-                           separatori, mai a metà valore ("Maturazione 24-72h"). */
-                        .map((tag) => tag.replace(/ /g, " "))
-                        .join(" · ")}
-                    </p>
-                  )}
-
-                  {introExtraSlot && (
-                    <div className="recipe-view-utility-row">
+                  {(heroTags.length > 0 || introExtraSlot) && (
+                    <div className="recipe-view-meta-row">
+                      {heroTags.length > 0 && (
+                        <p className="recipe-view-tags">
+                          {heroTags
+                            .map((tag) =>
+                              tag ? tag.charAt(0).toUpperCase() + tag.slice(1) : tag,
+                            )
+                            /* Ogni caratteristica è un'unità: va a capo solo sui
+                               separatori, mai a metà valore ("Maturazione 24-72h"). */
+                            .map((tag) => tag.replace(/ /g, " "))
+                            .join(" · ")}
+                        </p>
+                      )}
                       {introExtraSlot}
                     </div>
                   )}

--- a/src/app/features/recipe/recommended-styles.tsx
+++ b/src/app/features/recipe/recommended-styles.tsx
@@ -46,6 +46,14 @@ type RecommendationWithVariant = StyleRecommendation & {
   bestInterpretation: Interpretation | null;
 };
 
+function sortByVisibleMatch(items: RecommendationWithVariant[]): RecommendationWithVariant[] {
+  return [...items].sort((a, b) => {
+    const aScore = a.optimizedComposite ?? a.compatibilityScore;
+    const bScore = b.optimizedComposite ?? b.compatibilityScore;
+    return bScore - aScore;
+  });
+}
+
 /** Nome breve della variante per la card ("AVPN", "Franco Pepe"). */
 function variantShortName(it: Interpretation): string {
   const name =
@@ -266,22 +274,22 @@ export function RecommendedStyles({
     [
       {
         key: "perfect",
-        items: filtered.filter((r) => r.tier === "perfect"),
+        items: sortByVisibleMatch(filtered.filter((r) => r.tier === "perfect")),
       },
       {
         key: "good",
-        items: filtered.filter((r) => r.tier === "good"),
+        items: sortByVisibleMatch(filtered.filter((r) => r.tier === "good")),
       },
       {
         key: "challenging",
-        items: filtered.filter((r) => r.tier === "challenging"),
+        items: sortByVisibleMatch(filtered.filter((r) => r.tier === "challenging")),
       },
       {
         // Audit Sprint 12 — Sezione "Non fattibili": stili con incompatibilità
         // hard (forno legna assente, ecc.) o score molto basso. Mostrati per
         // trasparenza ("cosa non puoi fare e perché"), in stile muted.
         key: "not_feasible",
-        items: filtered.filter((r) => r.tier === "not_feasible"),
+        items: sortByVisibleMatch(filtered.filter((r) => r.tier === "not_feasible")),
       },
     ].filter((t) => t.items.length > 0);
 
@@ -368,6 +376,22 @@ export function RecommendedStyles({
             className="recommended-advanced-panel"
           >
             <div className="recommended-advanced-panel__body">
+              {hasActiveAdvanced && (
+                <div className="recommended-advanced-panel__actions">
+                  <motion.button
+                    type="button"
+                    onClick={() => {
+                      setHydrationFilter(null);
+                      setTextureFilter(null);
+                      setSkillFilter(null);
+                      setOvenFilter(null);
+                    }}
+                    className="recommended-advanced-panel__clear"
+                  >
+                    {cms.filters.removeFilters}
+                  </motion.button>
+                </div>
+              )}
               {/* Hydration */}
               <FacetRow
                 label={cms.filters.hydrationLabel}
@@ -417,19 +441,6 @@ export function RecommendedStyles({
                 onToggle={(v) => setOvenFilter(ovenFilter === v ? null : v)}
               />
 
-              {hasActiveAdvanced && (
-                <motion.button
-                  onClick={() => {
-                    setHydrationFilter(null);
-                    setTextureFilter(null);
-                    setSkillFilter(null);
-                    setOvenFilter(null);
-                  }}
-                  className="recommended-advanced-panel__clear"
-                >
-                  {cms.filters.removeFilters}
-                </motion.button>
-              )}
             </div>
           </motion.div>
         )}

--- a/src/app/features/recipe/recommended-styles.tsx
+++ b/src/app/features/recipe/recommended-styles.tsx
@@ -520,13 +520,6 @@ export function RecommendedStyles({
               </span>
             </div>
 
-            {/* Audit Sprint 12 — Not feasible: nota in cima alla griglia che chiarisce
-                perché questi stili non sono praticabili al momento. */}
-            {key === "not_feasible" && items.length > 0 && (
-              <p className="recommended-tier-note">
-                {cms.misc.notFeasibleExplainer}
-              </p>
-            )}
             <div
               data-region="collection"
               className={`recommended-collection${key === "not_feasible" ? " recommended-collection--muted" : ""}`}

--- a/src/app/features/recipe/style-detail-sheet.tsx
+++ b/src/app/features/recipe/style-detail-sheet.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { motion, useReducedMotion, AnimatePresence } from "motion/react";
-import { Droplets, Flame, Clock, ChefHat, Sparkles, X, Layers, Ratio, FlaskConical, Eye, EyeOff, Bookmark } from "lucide-react";
+import { Droplets, Flame, Clock, ChefHat, Sparkles, X, Layers, Ratio, FlaskConical, Eye, EyeOff, Bookmark, Heart } from "lucide-react";
 import { createPortal } from "react-dom";
 import { ImageWithFallback } from "../../components/media/ImageWithFallback";
 import { STYLE_PHOTOS, reasonDimension, MATCH_DIMENSION_ICON } from "./recommended-styles";
@@ -206,6 +206,7 @@ export function StyleDetailSheet({
                     ·
                   </span>
                   <span className="style-detail-title__match">
+                    <Heart size={10} fill="currentColor" aria-hidden="true" />
                     {rec.compatibilityScore}% Match
                   </span>
                 </>

--- a/src/app/features/recipe/user-needs.tsx
+++ b/src/app/features/recipe/user-needs.tsx
@@ -128,6 +128,12 @@ const FLOUR_OPTIONS_GENERIC: FlourOption[] = [
     detail: "Media forza",
   },
   {
+    id: "tipo_1",
+    name: "Farina tipo 1",
+    w: "W220–280",
+    detail: "Rustica, profumo di cereale",
+  },
+  {
     id: "manitoba",
     name: "Manitoba",
     w: "W340–380",

--- a/src/app/hooks/use-profile-defaults.ts
+++ b/src/app/hooks/use-profile-defaults.ts
@@ -116,6 +116,7 @@ function loadProfileDefaults(): ProfileDefaults {
         constraints.has_pizza_stone = constraints.surfaces.includes("refractory_brick") || constraints.surfaces.includes("cordierite_stone");
         constraints.has_pizza_steel = constraints.surfaces.includes("steel_plate");
         constraints.has_baking_pan = constraints.surfaces.includes("aluminum_pan") || constraints.surfaces.includes("blue_steel_pan") || constraints.surfaces.includes("cast_iron");
+        constraints.oven_heat_profile = equip.oven_heat_profile ?? constraints.oven_heat_profile;
       }
     }
   } catch { /* */ }

--- a/src/app/pages/explore.tsx
+++ b/src/app/pages/explore.tsx
@@ -149,7 +149,7 @@ function FeaturedRecipeCard({
           <p className="explore-feature__desc">
             Una delle combinazioni più celebri per lo stile{" "}
             <strong className="explore-feature__desc-strong">{styleName}</strong>
-            {authorLabel ? ` via ${authorLabel}` : ""}. Scopri i parametri dell'impasto consigliati, i tempi e il condimento autentico.
+            {authorLabel ? ` secondo ${authorLabel}` : ""}. Scopri i parametri dell'impasto consigliati, i tempi e il condimento autentico.
           </p>
         </div>
 
@@ -537,12 +537,12 @@ function SignatureRecipeCard({
   const styleName =
     STYLES_DB[recipe.style_id]?.name ?? recipe.style_id;
 
-  /* Autore/locale dall'interpretazione (se mappata): mostrato come "via X"
+  /* Autore/locale dall'interpretazione (se mappata): mostrato come "Secondo X"
    * sopra al titolo, e propagato come deep-link ?interpretation=<id>.
    * Audit motore 2026-05: dedup vs authenticity_badge — se il badge in alto
    * già contiene il nome dell'organizzazione (es. badge "Disciplinare AVPN"
    * + organization "AVPN — Associazione Verace Pizza Napoletana"),
-   * sopprime "via X" perché ridondante. */
+   * sopprime "Secondo X" perché ridondante. */
   const interpretation = recipe.interpretation_id
     ? getInterpretationById(recipe.interpretation_id)
     : undefined;
@@ -620,7 +620,7 @@ function SignatureRecipeCard({
             {/* Sprint 12 — autore/locale dell'interpretazione (se mappata). */}
             {authorLabel && (
               <div className="explore-card__author">
-                via {authorLabel}
+                Secondo {authorLabel}
               </div>
             )}
           </div>

--- a/src/app/pages/explore.tsx
+++ b/src/app/pages/explore.tsx
@@ -3,7 +3,7 @@
    Layout editoriale e filtri flessibili (Spotify/Pinterest style).
    Tab: Stili — /explore */
 
-import { ArrowRight, ChevronUp } from "lucide-react";
+import { ArrowRight, ChevronUp, Heart, HeartCrack, HeartHandshake, HeartOff, HeartPulse } from "lucide-react";
 import { AnimatePresence,motion } from "motion/react";
 import { useMemo, useState } from "react";
 import { Link,useSearchParams } from "react-router";
@@ -71,6 +71,20 @@ function isExploreFilter(value: string | null): value is ExploreFilter {
 
 function isFamilyFilter(value: string | null): value is FamilyId | "all" {
   return FAMILY_IDS.includes(value as FamilyId | "all");
+}
+
+function MatchHeartIcon({ score }: { score: number }) {
+  const Icon =
+    score >= 90
+      ? HeartHandshake
+      : score >= 75
+        ? Heart
+        : score >= 60
+          ? HeartPulse
+          : score >= 40
+            ? HeartCrack
+            : HeartOff;
+  return <Icon size={11} fill={score >= 60 ? "currentColor" : "none"} aria-hidden="true" className="explore-card__match-icon" />;
 }
 
 /* ── Componente Editoriale per la Ricetta in Primo Piano ── */
@@ -711,6 +725,7 @@ function StyleCatalogCard({
                 title={match.headroom > 0 ? `Ottimizzabile: ${match.mc}% → ${match.mc + match.headroom}% col tuo setup` : `Match: ${match.mc}%`}
                 aria-label={match.headroom > 0 ? `Compatibilità ${match.mc}%, ottimizzabile fino a ${match.mc + match.headroom}% col tuo setup` : `Compatibilità ${match.mc}%`}
               >
+                <MatchHeartIcon score={match.mc} />
                 <span className="explore-card__match-mc">{match.mc}%</span>
                 {match.headroom > 0 && (
                   <>

--- a/src/app/pages/home.tsx
+++ b/src/app/pages/home.tsx
@@ -1,4 +1,5 @@
 import {
+ArrowDown,
 Bookmark,
 ChevronLeft,
 ChevronRight,
@@ -390,6 +391,10 @@ function WelcomeOnboardingCard({
         <Link to="/profile" onClick={onDismiss} className="home-onboarding__link">
           {profileCta}
         </Link>
+      </div>
+      <div className="home-onboarding__guide" aria-hidden="true">
+        <span className="home-onboarding__guide-line" />
+        <ArrowDown size={14} strokeWidth={1.5} />
       </div>
     </motion.div>
   );
@@ -905,8 +910,7 @@ export function HomePage() {
     () => (selectedStyle ? deriveFeedbackCorrections(selectedStyle.id, loadFeedback()) : null),
     [selectedStyle],
   );
-  const showFeedbackPanel =
-    Boolean(feedbackCorrection) && selectedStyle != null && feedbackAppliedStyle !== selectedStyle.id;
+  const showFeedbackPanel = false;
   const applyFeedbackCorrection = useCallback(() => {
     if (!feedbackCorrection || !selectedStyle) return;
     if (feedbackCorrection.hydrationDelta !== 0) {
@@ -1309,9 +1313,6 @@ export function HomePage() {
                           {cms.hero.title_line2}
                         </span>
                       </Heading>
-                      <p className="home-hero__subtitle">
-                        {cms.hero.subtitle}
-                      </p>
                     </motion.div>
                   }
                 />

--- a/src/app/pages/profile.tsx
+++ b/src/app/pages/profile.tsx
@@ -1208,6 +1208,7 @@ export function ProfilePage() {
   const currentLocale = useMemo(() => {
     return LOCALE_META.find((l) => l.id === cms.locale?.id) ?? LOCALE_META[0];
   }, [cms.locale?.id]);
+  const [profileTab, setProfileTab] = useState<"setup" | "app" | "recipes">("setup");
 
   /* FTU */
   if (showFtu) {
@@ -1268,11 +1269,39 @@ export function ProfilePage() {
           </p>
         </div>
 
+        <div className="profile-tabs" role="tablist" aria-label={p.pageTitle}>
+          {[
+            { id: "setup" as const, label: "Il tuo setup" },
+            { id: "app" as const, label: "App" },
+            { id: "recipes" as const, label: "Ricette" },
+          ].map((tab) => {
+            const active = profileTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => setProfileTab(tab.id)}
+                className={active ? "profile-tabs__button profile-tabs__button--active" : "profile-tabs__button"}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+
         {/* ── STILI PREFERITI + RICETTARIO (R31) — visibili solo se ne hai ── */}
-        <FavoriteStylesSection />
-        <SavedRecipesSection />
+        {profileTab === "recipes" && (
+          <>
+            <FavoriteStylesSection />
+            <SavedRecipesSection />
+          </>
+        )}
 
         {/* ── FORNO ── */}
+        {profileTab === "setup" && (
+          <>
         <ProfileSection
           title={p.ovenTitle}
           subtitle={p.ovenSubtitle}
@@ -1787,8 +1816,12 @@ export function ProfilePage() {
             )}
           </div>
         </ProfileSection>
+          </>
+        )}
 
         {/* ── LINGUA & TEMA ── */}
+        {profileTab === "app" && (
+          <>
         <ProfileSection
           title={p.prefsTitle}
           subtitle={p.prefsSubtitle}
@@ -1979,6 +2012,8 @@ export function ProfilePage() {
             {devMode ? p.devModeOn : p.devModeOff}
           </motion.button>
         </div>
+          </>
+        )}
 
         {/* Locale confirmation modal */}
         <AnimatePresence>

--- a/src/app/pages/profile.tsx
+++ b/src/app/pages/profile.tsx
@@ -55,6 +55,7 @@ import {
 import type {
 EquipmentState,
 MixerType,
+OvenHeatProfile,
 SurfaceType,
 ToolCategory,
 } from "../data/equipment-data";
@@ -172,6 +173,56 @@ const OVEN_ICONS: Record<string, typeof Flame> = {
   gas: Flame,
   wood: Trees, // Differenziato da gas (Flame) — gruppo di alberi più riconoscibile
 };
+
+const OVEN_HEAT_PROFILES: {
+  id: OvenHeatProfile;
+  label: string;
+  description: string;
+  bestFor: OvenType[];
+}[] = [
+  {
+    id: "static_top_bottom",
+    label: "Sopra + sotto",
+    description: "Statico classico: equilibrio fra base e cielo.",
+    bestFor: ["home", "electric_standard", "electric_high"],
+  },
+  {
+    id: "top_grill",
+    label: "Grill superiore",
+    description: "Cielo forte per cornicione e doratura finale.",
+    bestFor: ["home", "electric_standard"],
+  },
+  {
+    id: "bottom_boost",
+    label: "Spinta dal basso",
+    description: "Base intensa: utile per teglie, acciaio e croccantezza.",
+    bestFor: ["electric_standard", "electric_high"],
+  },
+  {
+    id: "fan_assisted",
+    label: "Ventilato",
+    description: "Aria in movimento: asciuga e uniforma, va gestita.",
+    bestFor: ["home", "electric_standard"],
+  },
+  {
+    id: "gas_bottom",
+    label: "Gas sotto",
+    description: "Fiamma sotto la platea, rotazione a meta cottura.",
+    bestFor: ["gas"],
+  },
+  {
+    id: "gas_rear",
+    label: "Bruciatore dietro",
+    description: "Calore direzionale: rotazioni frequenti e piccole.",
+    bestFor: ["gas"],
+  },
+  {
+    id: "wood_side_flame",
+    label: "Fiamma laterale",
+    description: "Fiamma viva di lato, gestione come forno a legna.",
+    bestFor: ["wood"],
+  },
+];
 
 /* Pantry data removed — managed in user-needs.tsx */
 
@@ -338,53 +389,69 @@ function SavedRecipesSection() {
     };
   }, []);
 
-  if (recipes.length === 0) return null;
-
   return (
     <ProfileSection
       title={p.savedRecipesTitle}
       subtitle={p.savedRecipesSubtitle}
       delay={0.03}
     >
-      <div className="profile-saved-recipes">
-        {recipes.map((r) => {
-          const styleName = STYLES_DB[r.styleId]?.name ?? r.styleName;
-          const meta = [
-            formatSavedDate(r.createdAt),
-            r.score != null ? `${r.score}/100` : null,
-          ]
-            .filter(Boolean)
-            .join(" · ");
-          return (
-            <div key={r.id} className="profile-saved-recipes__item">
-              <Link
-                to={buildSavedRecipeUrl(r)}
-                className="profile-saved-recipes__link"
-              >
-                <span className="profile-saved-recipes__icon">
-                  <Bookmark size={17} fill="currentColor" />
-                </span>
-                <div className="profile-saved-recipes__info">
-                  <span className="profile-saved-recipes__name">
-                    {styleName}
+      {recipes.length === 0 ? (
+        <div className="profile-saved-recipes__empty">
+          <span className="profile-saved-recipes__empty-icon" aria-hidden="true">
+            <Bookmark size={22} />
+          </span>
+          <div className="profile-saved-recipes__empty-copy">
+            <Heading level="sm" as="h3">
+              {p.savedRecipesEmptyTitle}
+            </Heading>
+            <p>{p.savedRecipesEmptyBody}</p>
+          </div>
+          <CtaButton as={Link} to="/explore" variant="secondary" radius="lg">
+            {p.savedRecipesEmptyCta}
+            <ChevronRight size={17} aria-hidden="true" />
+          </CtaButton>
+        </div>
+      ) : (
+        <div className="profile-saved-recipes">
+          {recipes.map((r) => {
+            const styleName = STYLES_DB[r.styleId]?.name ?? r.styleName;
+            const meta = [
+              formatSavedDate(r.createdAt),
+              r.score != null ? `${r.score}/100` : null,
+            ]
+              .filter(Boolean)
+              .join(" · ");
+            return (
+              <div key={r.id} className="profile-saved-recipes__item">
+                <Link
+                  to={buildSavedRecipeUrl(r)}
+                  className="profile-saved-recipes__link"
+                >
+                  <span className="profile-saved-recipes__icon">
+                    <Bookmark size={17} fill="currentColor" />
                   </span>
-                  <span className="type-data profile-saved-recipes__meta">
-                    {meta}
-                  </span>
-                </div>
-              </Link>
-              <button
-                onClick={() => setRecipes(removeRecipe(r.id))}
-                className="profile-saved-recipes__remove"
-                aria-label={t(p.savedRecipeRemoveAria, { name: styleName })}
-                title={p.savedRecipeRemove}
-              >
-                <X size={16} />
-              </button>
-            </div>
-          );
-        })}
-      </div>
+                  <div className="profile-saved-recipes__info">
+                    <span className="profile-saved-recipes__name">
+                      {styleName}
+                    </span>
+                    <span className="type-data profile-saved-recipes__meta">
+                      {meta}
+                    </span>
+                  </div>
+                </Link>
+                <button
+                  onClick={() => setRecipes(removeRecipe(r.id))}
+                  className="profile-saved-recipes__remove"
+                  aria-label={t(p.savedRecipeRemoveAria, { name: styleName })}
+                  title={p.savedRecipeRemove}
+                >
+                  <X size={16} />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </ProfileSection>
   );
 }
@@ -1069,6 +1136,10 @@ export function ProfilePage() {
     });
   }, [updateEquipment]);
 
+  const setOvenHeatProfile = useCallback((id: OvenHeatProfile) => {
+    updateEquipment((prev) => ({ ...prev, oven_heat_profile: id }));
+  }, [updateEquipment]);
+
   const toggleTool = useCallback((id: string) => {
     updateEquipment((prev) => {
       const tools = prev.tools.includes(id)
@@ -1271,9 +1342,9 @@ export function ProfilePage() {
 
         <div className="profile-tabs" role="tablist" aria-label={p.pageTitle}>
           {[
-            { id: "setup" as const, label: "Il tuo setup" },
+            { id: "recipes" as const, label: "Ricette salvate" },
+            { id: "setup" as const, label: "La tua cucina" },
             { id: "app" as const, label: "App" },
-            { id: "recipes" as const, label: "Ricette" },
           ].map((tab) => {
             const active = profileTab === tab.id;
             return (
@@ -1389,6 +1460,54 @@ export function ProfilePage() {
               className="profile-oven-temp__slider"
               aria-label={p.tempAria}
             />
+          </div>
+
+          <div className="profile-oven-heat">
+            <div className="profile-oven-heat__head">
+              <span className="type-data-sm profile-oven-heat__label">
+                Distribuzione del calore
+              </span>
+              <span className="type-data-xs profile-oven-heat__hint">
+                Cambia preriscaldo, ripiano e rotazioni.
+              </span>
+            </div>
+            <div className="profile-oven-heat__grid">
+              {OVEN_HEAT_PROFILES.map((profile) => {
+                const active = (equipment.oven_heat_profile ?? "static_top_bottom") === profile.id;
+                const suggested = profile.bestFor.includes(ovenType);
+                return (
+                  <motion.button
+                    key={profile.id}
+                    type="button"
+                    onClick={() => setOvenHeatProfile(profile.id)}
+                    className={
+                      active
+                        ? "profile-oven-heat__option profile-oven-heat__option--active"
+                        : "profile-oven-heat__option"
+                    }
+                    animate={{
+                      borderColor: active ? "var(--primary)" : "var(--container-border)",
+                      backgroundColor: active ? "var(--surface-container)" : "var(--container-bg-low)",
+                    }}
+                    transition={{ type: "spring", stiffness: 500, damping: 35 }}
+                  >
+                    <span className="profile-oven-heat__option-row">
+                      <span className="type-body-sm profile-oven-heat__option-label">
+                        {profile.label}
+                      </span>
+                      {suggested && (
+                        <span className="profile-oven-heat__option-badge">
+                          adatto
+                        </span>
+                      )}
+                    </span>
+                    <span className="type-data-xs profile-oven-heat__option-desc">
+                      {profile.description}
+                    </span>
+                  </motion.button>
+                );
+              })}
+            </div>
           </div>
         </ProfileSection>
 

--- a/src/app/pages/recipe.tsx
+++ b/src/app/pages/recipe.tsx
@@ -922,8 +922,7 @@ function RecipeContent({
     () => deriveFeedbackCorrections(style.id, loadFeedback()),
     [style.id],
   );
-  const showFeedbackPanel =
-    Boolean(feedbackCorrection) && feedbackAppliedStyle !== style.id;
+  const showFeedbackPanel = false;
   const applyFeedbackCorrection = useCallback(() => {
     if (!feedbackCorrection) return;
     // Applicare una correzione = personalizzare: esci dal canonico e tieni il TUO

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1861,10 +1861,12 @@
   .explore-page__accent { transition: all 0.3s ease; }
   .explore-page__accent--nerd { background: var(--gradient-nerd); color: transparent; -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
   .explore-page__lead { max-width: var(--measure-sm); line-height: var(--leading-relaxed); margin-top: var(--space-3); }
-  .explore-filters { display: flex; gap: var(--gap-xs); margin-bottom: var(--space-8); overflow-x: auto; padding-bottom: var(--space-1); }
-  .explore-filters__chip { display: flex; align-items: center; gap: var(--space-1-5); padding-inline: var(--space-4); padding-block: var(--space-2); border-radius: var(--radius-xl); flex-shrink: 0; background: var(--container-bg); color: var(--text-default); border: 1px solid var(--container-border); box-shadow: none; font-size: var(--font-size-lg); font-weight: var(--weight-semibold); cursor: pointer; outline: none; transition: all 0.3s ease; }
-  .explore-filters__chip:active { transform: scale(0.95); }
-  .explore-filters__chip--active { background: var(--primary); color: white; border-color: var(--primary); }
+  .explore-filters { display: flex; gap: var(--gap-xs); margin-bottom: var(--space-8); overflow-x: auto; padding: var(--space-1); border-radius: var(--radius-2xl); background: color-mix(in srgb, var(--surface-container-low) 72%, transparent); border: var(--border-width-thin) solid var(--container-border-subtle); }
+  .explore-filters__chip { display: flex; align-items: center; gap: var(--space-1-5); padding-inline: var(--space-4); padding-block: var(--space-2); border-radius: var(--radius-xl); flex-shrink: 0; background: var(--container-bg); color: var(--text-default); border: 1px solid var(--container-border); box-shadow: none; font-size: var(--font-size-lg); font-weight: var(--weight-semibold); cursor: pointer; outline: none; transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease; }
+  .explore-filters__chip:hover { transform: translateY(calc(-1 * var(--space-px))); border-color: color-mix(in srgb, var(--primary) 28%, var(--container-border)); box-shadow: var(--shadow-sm); }
+  .explore-filters__chip:focus-visible { outline: var(--space-0-5) solid color-mix(in srgb, var(--primary) 32%, transparent); outline-offset: var(--space-0-5); }
+  .explore-filters__chip:active { transform: scale(0.96); }
+  .explore-filters__chip--active { background: var(--primary); color: var(--overlay-text); border-color: var(--primary); box-shadow: var(--shadow-glow), var(--shadow-sm); }
   .explore-filters__chip--nerd { background: var(--gradient-nerd); border-color: transparent; box-shadow: var(--glow-chip-nerd); }
   .explore-section-stack { display: flex; flex-direction: column; gap: var(--space-10); }
   .explore-section__head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: var(--space-4); }
@@ -1929,7 +1931,7 @@
   .explore-card__caption { position: absolute; bottom: 0; left: 0; right: 0; padding-inline: var(--space-4); padding-bottom: var(--space-3-5); padding-top: var(--space-16); }
   @media (min-width: 640px) { .explore-card__caption { padding-bottom: var(--space-4); } }
   .explore-card__eyebrow { font-size: var(--font-size-sm); font-weight: var(--weight-semibold); letter-spacing: var(--tracking-label); text-transform: uppercase; color: var(--overlay-text-warm); text-shadow: var(--overlay-shadow-text-sm); margin-bottom: var(--space-1); }
-  .explore-card__title { font-family: var(--font-serif); hyphens: auto; overflow-wrap: break-word; font-weight: var(--weight-bold); line-height: var(--leading-snug); color: var(--overlay-text); text-shadow: var(--overlay-shadow-text); display: block; letter-spacing: var(--tracking-snug); }
+  .explore-card__title { font-family: var(--font-serif); hyphens: manual; overflow-wrap: normal; word-break: normal; text-wrap: balance; font-weight: var(--weight-bold); line-height: var(--leading-snug); color: var(--overlay-text); text-shadow: var(--overlay-shadow-text); display: block; letter-spacing: var(--tracking-snug); }
   .explore-card__title--recipe { font-size: min(clamp(var(--font-size-2xl), 3vw, var(--font-size-5xl)), 12cqw); }
   .explore-card__title--style { font-size: min(clamp(var(--font-size-3xl), 3.5vw, var(--font-size-6-5xl)), 10.5cqw); }
   .explore-card__author { margin-top: var(--space-1); font-size: var(--font-size-xs); font-weight: var(--weight-medium); letter-spacing: var(--tracking-snug); color: var(--overlay-text-warm); text-shadow: var(--overlay-shadow-text-sm); opacity: 0.92; }
@@ -2733,7 +2735,7 @@
     max-width: var(--measure-3xl);
     justify-content: center;
     padding-inline: var(--space-4);
-    padding-block: var(--space-8) var(--space-36);
+    padding-block: var(--space-2) var(--space-28);
   }
   @media (min-width: 640px) {
     .home-footer {
@@ -2742,7 +2744,7 @@
   }
   @media (min-width: 768px) {
     .home-footer {
-      padding-bottom: var(--space-12);
+      padding-bottom: var(--space-8);
     }
   }
   @media (min-width: 1024px) {
@@ -2755,9 +2757,9 @@
     align-items: center;
     gap: var(--space-1-5);
     color: var(--text-muted);
-    font-size: var(--font-size-xs);
-    font-weight: var(--weight-medium);
-    opacity: 0.35;
+    font-size: var(--font-size-sm);
+    font-weight: var(--weight-semibold);
+    opacity: 0.72;
     letter-spacing: var(--tracking-spread);
   }
   .home-footer__heart {
@@ -2947,6 +2949,12 @@
   .profile-page__header-icon { display: inline-flex; align-items: center; justify-content: center; margin-bottom: var(--space-3); width: var(--space-13); height: var(--space-13); border-radius: var(--radius-lg); background: var(--surface-container); }
   .profile-page__header-icon-glyph { color: var(--primary); }
   .profile-page__subtitle { font-family: var(--font-serif); font-style: italic; margin-top: var(--space-1); font-size: var(--font-size-xl); color: var(--text-muted); opacity: 0.65; }
+  .profile-tabs { position: sticky; top: var(--space-3); z-index: 4; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-1); margin-bottom: var(--space-5); padding: var(--space-1); border-radius: var(--radius-2xl); background: color-mix(in srgb, var(--container-page) 86%, transparent); border: var(--border-width-thin) solid var(--container-border-subtle); box-shadow: var(--shadow-sm); backdrop-filter: blur(var(--blur-md)); -webkit-backdrop-filter: blur(var(--blur-md)); }
+  .profile-tabs__button { min-width: 0; padding-inline: var(--space-2); padding-block: var(--space-2); border-radius: var(--radius-xl); color: var(--text-muted); font-size: var(--font-size-sm); font-weight: var(--weight-semibold); line-height: var(--leading-tight); cursor: pointer; transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease, box-shadow 0.18s ease; }
+  .profile-tabs__button:hover { color: var(--text-default); background: var(--surface-container-low); }
+  .profile-tabs__button:focus-visible { outline: var(--space-0-5) solid color-mix(in srgb, var(--primary) 30%, transparent); outline-offset: var(--space-0-5); }
+  .profile-tabs__button:active { transform: scale(0.97); }
+  .profile-tabs__button--active { color: var(--chip-text-active); background: var(--chip-bg-active); box-shadow: var(--shadow-sm); }
 
   /* ── Oven section (profile main) ── */
   .profile-oven-list { display: flex; flex-direction: column; gap: var(--gap-xs); }
@@ -4286,6 +4294,16 @@
     gap: var(--space-1-5);
   }
 
+  .setup-versions--binary {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-1);
+    padding: var(--space-1);
+    border-radius: var(--radius-2xl);
+    background: var(--surface-container-low);
+    border: var(--border-width-thin) solid var(--container-border-subtle);
+  }
+
   .setup-signatures {
     display: flex;
     flex-direction: column;
@@ -4305,6 +4323,7 @@
 
   /* ── Option rows (versions + interpretations, shared) ── */
   .setup-option {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -4351,6 +4370,25 @@
   .setup-option__check {
     flex-shrink: 0;
     color: var(--tertiary);
+  }
+
+  .setup-option--binary {
+    justify-content: center;
+    min-height: var(--space-15);
+    padding-inline: var(--space-3);
+    padding-block: var(--space-2-5);
+    border-color: transparent;
+    background: transparent;
+    text-align: center;
+  }
+  .setup-option--binary.setup-option--active {
+    background: var(--container-bg);
+    border-color: color-mix(in srgb, var(--tertiary) 38%, var(--container-border));
+    box-shadow: var(--shadow-sm);
+  }
+  .setup-option--binary .setup-option__check {
+    position: absolute;
+    right: var(--space-2-5);
   }
 
   /* ── Children slot (configurator) + science block: shared border-top ── */
@@ -4909,6 +4947,7 @@
     align-items: center;
     gap: var(--gap-sm);
     margin-bottom: var(--space-5);
+    padding-bottom: var(--space-1);
   }
   @media (min-width: 640px) {
     .ingredients-header { gap: var(--gap-md); }
@@ -4922,7 +4961,12 @@
   .ingredients-header__divider {
     flex: 1;
     height: var(--border-width-thin);
-    background: var(--container-divider);
+    background: linear-gradient(
+      to right,
+      color-mix(in srgb, var(--primary) 42%, transparent),
+      color-mix(in srgb, var(--container-divider) 72%, transparent)
+    );
+    opacity: 0.82;
   }
   .ingredients-header__copy {
     display: flex;
@@ -4936,6 +4980,10 @@
     font-weight: var(--weight-medium);
     background: var(--recipe-bg);
     border: var(--border-width-thin) solid var(--recipe-border);
+  }
+  .ingredients-header__copy:hover {
+    color: var(--primary);
+    border-color: color-mix(in srgb, var(--primary) 28%, var(--recipe-border));
   }
   .ingredients-header__copy:active {
     transform: scale(0.95);
@@ -5632,14 +5680,16 @@
 
   .procedure-hero__time-suffix {
     display: block;
-    font-weight: var(--weight-medium);
-    color: var(--text-muted);
+    font-weight: var(--weight-semibold);
+    color: var(--primary);
     line-height: var(--leading-tight);
     margin-top: var(--space-0-5);
-    min-height: 2.2em;
+    min-height: 1em;
     max-width: 100%;
     white-space: normal;
     visibility: visible;
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
   }
   .procedure-hero__time-suffix--hidden {
     visibility: hidden;
@@ -6228,6 +6278,18 @@
     font-weight: var(--weight-semibold);
     line-height: var(--leading-tight);
     flex-shrink: 0;
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: var(--space-0-5);
+  }
+  .bits-ing-row__amount-note {
+    color: var(--text-muted);
+    font-size: var(--font-size-2xs);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-none);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
   }
 
   /* ── GlossaryWLink ── */
@@ -6541,13 +6603,15 @@
   .recipe-view-back--hidden { pointer-events: none; }
 
   .recipe-view-back__button {
-    background: color-mix(in srgb, var(--container-page) 85%, transparent);
+    background: color-mix(in srgb, var(--container-page) 94%, transparent);
     backdrop-filter: blur(var(--blur-md));
     -webkit-backdrop-filter: blur(var(--blur-md));
     color: var(--text-default);
-    border: var(--border-width-thin) solid var(--container-border);
-    transition: transform 0.15s;
+    border: var(--border-width-thin) solid color-mix(in srgb, var(--primary) 28%, var(--container-border));
+    box-shadow: var(--shadow-float);
+    transition: transform 0.15s, background 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
+  .recipe-view-back__button:hover { background: var(--container-bg); border-color: color-mix(in srgb, var(--primary) 45%, var(--container-border)); box-shadow: var(--shadow-float), var(--shadow-glow); }
   .recipe-view-back__button:active { transform: scale(0.9); }
 
   /* ── Hero photo ── */
@@ -6741,24 +6805,6 @@
     margin: 0;
   }
 
-  .recipe-view-share {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1-5);
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    font-size: inherit;
-    font-weight: var(--weight-semibold);
-    font-style: normal;
-    color: var(--text-accent);
-    text-decoration: underline;
-    transition: transform 0.15s;
-  }
-  .recipe-view-share:active { transform: scale(0.95); }
-  .recipe-view-share--copied { color: var(--recipe-success); }
-
   /* ── Contenuto ── */
   .recipe-view-body {
     max-width: var(--measure-6xl);
@@ -6834,6 +6880,10 @@
     white-space: nowrap;
     margin-top: var(--space-0-5); /* 2px */
   }
+  .stat-strip__value--changed {
+    align-items: center;
+    gap: var(--space-1);
+  }
 
   .stat-strip__value-main {
     font-size: clamp(var(--font-size-xl), 4.4vw, var(--font-size-2xl));
@@ -6853,6 +6903,22 @@
   .stat-strip__value-sub--small {
     font-size: var(--font-size-xs);
   }
+  .stat-strip__value-prev {
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    font-weight: var(--weight-semibold);
+    text-decoration-line: line-through;
+    text-decoration-color: color-mix(in srgb, var(--text-muted) 56%, transparent);
+    text-decoration-thickness: var(--border-width-thin);
+  }
+  .stat-strip__value-arrow {
+    color: var(--text-muted);
+    opacity: 0.72;
+  }
+  .stat-strip__value-star {
+    color: var(--cta);
+    filter: drop-shadow(0 0 var(--space-1-5) color-mix(in srgb, var(--cta) 40%, transparent));
+  }
 
   .stat-strip__value-trend {
     display: inline-flex;
@@ -6871,6 +6937,10 @@
     display: flex;
     align-items: center;
     gap: var(--gap-xs);
+    padding: var(--space-1);
+    border-radius: var(--radius-2xl);
+    background: color-mix(in srgb, var(--surface-container-low) 74%, transparent);
+    border: var(--border-width-thin) solid var(--container-border-subtle);
   }
 
   .interpretation-switcher__scroll {
@@ -6884,6 +6954,15 @@
     margin-inline: calc(var(--space-0-5) * -1);
     scrollbar-width: none;
   }
+  @media (min-width: 768px) {
+    .interpretation-switcher {
+      padding: var(--space-1-5);
+      box-shadow: inset 0 0 0 var(--border-width-thin) color-mix(in srgb, var(--overlay-text) 4%, transparent);
+    }
+    .interpretation-switcher__scroll {
+      gap: var(--space-1-5);
+    }
+  }
 
   .interpretation-switcher__chip {
     flex-shrink: 0;
@@ -6893,23 +6972,30 @@
     padding-inline: var(--space-2-5);
     padding-block: var(--space-1);
     white-space: nowrap;
-    background: transparent;
-    border: var(--border-width-thin) solid transparent;
+    background: var(--container-bg);
+    border: var(--border-width-thin) solid var(--container-border-subtle);
     color: var(--text-muted);
     font-size: var(--font-size-sm);
     font-weight: var(--weight-medium);
     line-height: var(--leading-tight);
     cursor: pointer;
-    transition: all 0.15s ease;
+    box-shadow: var(--shadow-xs);
+    transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  }
+  .interpretation-switcher__chip:hover {
+    color: var(--text-default);
+    border-color: color-mix(in srgb, var(--primary) 24%, var(--container-border));
+    transform: translateY(calc(-1 * var(--space-px)));
   }
   .interpretation-switcher__chip:active {
     transform: scale(0.95);
   }
   .interpretation-switcher__chip--active {
-    background: color-mix(in srgb, var(--primary) 10%, transparent);
-    border-color: color-mix(in srgb, var(--primary) 28%, transparent);
+    background: color-mix(in srgb, var(--primary) 14%, var(--container-bg));
+    border-color: color-mix(in srgb, var(--primary) 45%, transparent);
     color: var(--primary);
     font-weight: var(--weight-semibold);
+    box-shadow: var(--shadow-sm), 0 0 0 var(--border-width-thin) color-mix(in srgb, var(--primary) 12%, transparent);
   }
 
   .interpretation-switcher__more {
@@ -9270,15 +9356,22 @@
   background: var(--surface-container-low);
   border: var(--border-width-thin) solid var(--outline-variant);
 }
+.recommended-advanced-panel__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: calc(-1 * var(--space-1));
+}
 .recommended-advanced-panel__clear {
-  align-self: flex-start;
-  padding-inline: var(--space-3);
-  padding-block: var(--space-1-5);
-  border-radius: var(--radius-lg);
+  padding-inline: var(--space-1);
+  padding-block: var(--space-1);
+  border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
   color: var(--primary);
-  background: color-mix(in srgb, var(--primary) 8%, var(--surface-container));
-  border: var(--border-width-thin) solid color-mix(in srgb, var(--primary) 20%, var(--outline-variant));
+  background: transparent;
+  border: none;
+  text-decoration-line: underline;
+  text-decoration-thickness: var(--border-width-thin);
+  text-underline-offset: var(--space-1);
 }
 .recommended-advanced-panel__clear:active {
   transform: scale(0.95);
@@ -9332,6 +9425,7 @@
   align-items: center;
   gap: var(--space-3);
   margin-bottom: var(--space-3);
+  padding-right: var(--space-2);
 }
 .recommended-tier-header__icon {
   width: var(--space-8);
@@ -9345,8 +9439,10 @@
 }
 .recommended-tier-header__titles {
   display: flex;
-  align-items: baseline;
-  gap: var(--gap-2xs);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-0-5);
+  min-width: 0;
 }
 .recommended-tier-header__label {
   color: var(--text-default);
@@ -9369,12 +9465,22 @@
   flex: 1 1 0%;
   height: var(--border-width-thin);
   margin-left: var(--space-2);
-  background: var(--container-divider);
+  background: linear-gradient(
+    to right,
+    color-mix(in srgb, var(--primary) 30%, transparent),
+    color-mix(in srgb, var(--container-divider) 70%, transparent)
+  );
+  opacity: 0.75;
 }
 .recommended-tier-header__count {
   color: var(--text-muted);
   font-size: var(--font-size-md);
   font-feature-settings: "tnum";
+  padding-inline: var(--space-2-5);
+  padding-block: var(--space-0-5);
+  border-radius: var(--radius-full);
+  background: var(--surface-container-low);
+  border: var(--border-width-thin) solid var(--container-border-subtle);
 }
 
 /* ── "Non fattibili" explainer note ── */
@@ -10573,6 +10679,9 @@
     transform-origin: bottom center;
     will-change: transform, opacity;
   }
+  .app-shell-dock--scrolled {
+    bottom: calc(var(--space-4) + env(safe-area-inset-bottom, 0px));
+  }
 
   @media (min-width: 768px) {
     .app-shell-dock {
@@ -10590,6 +10699,10 @@
     border: var(--border-width-thin) solid var(--premium-glass-border);
     box-shadow: var(--premium-glass-shadow);
     border-radius: var(--radius-2xl);
+  }
+  .app-shell-dock--scrolled .app-shell-dock__nav {
+    background: color-mix(in srgb, var(--container-page) 88%, transparent);
+    box-shadow: var(--premium-glass-shadow), 0 0 0 var(--border-width-thin) color-mix(in srgb, var(--overlay-text) 5%, transparent);
   }
 
   .app-shell-dock__gloss {
@@ -12573,6 +12686,18 @@
     justify-content: center;
     flex-shrink: 0;
     cursor: pointer;
+    outline: none;
+    transition: transform 0.16s ease, background 0.16s ease, border-color 0.16s ease, color 0.16s ease, box-shadow 0.16s ease, opacity 0.16s ease;
+  }
+  .ds-iconbtn:hover {
+    transform: translateY(calc(-1 * var(--space-px)));
+  }
+  .ds-iconbtn:active {
+    transform: scale(0.94);
+  }
+  .ds-iconbtn:focus-visible {
+    outline: var(--space-0-5) solid color-mix(in srgb, var(--primary) 35%, transparent);
+    outline-offset: var(--space-0-5);
   }
 
   /* Size */
@@ -12594,6 +12719,12 @@
     background: var(--surface-container);
     color: var(--icon-muted);
     border: var(--border-width-thin) solid var(--outline-variant);
+  }
+  .ds-iconbtn--surface:hover {
+    color: var(--text-default);
+    background: var(--container-bg);
+    border-color: color-mix(in srgb, var(--primary) 26%, var(--outline-variant));
+    box-shadow: var(--shadow-sm);
   }
   .ds-iconbtn--ghost {
     background: transparent;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -227,7 +227,7 @@
   --tracking-display: 0.14em;
   --tracking-extreme: 0.18em;
   --tracking-cooking-eyebrow: 0.16em; /* eyebrow header cooking-mode (fra ultra 0.12 e extreme 0.18) */
-  --tracking-colossal: 0.34em; /* wordmark-grade spacing */
+  --tracking-wordmark: 0.24em; /* brand name sotto il mark hero */
 
   /* ── Typography Primitives · Weight ── */
   --weight-regular: 400;
@@ -372,10 +372,10 @@
   --background: var(--color-parchment-50);
   --foreground: var(--color-night-1000);
   --card: var(--color-parchment-0);
-  --primary: var(--color-terracotta-500);
+  --primary: var(--color-terracotta-600);
   --ring: var(--color-terracotta-600);
   --primary-foreground: var(--color-white);
-  --secondary: var(--color-mocha-500);
+  --secondary: var(--color-mocha-700);
   --secondary-foreground: var(--color-white);
   --muted: var(--color-parchment-200);
   --muted-foreground: var(--color-mocha-700);
@@ -408,7 +408,7 @@
   --surface-container-high: var(--color-parchment-600);
   --surface-container-highest: var(--color-parchment-700);
   --on-surface: var(--color-night-1000);
-  --on-surface-variant: var(--color-mocha-600);
+  --on-surface-variant: var(--color-mocha-700);
   --outline: var(--color-parchment-700);
   --outline-variant: var(--color-parchment-500);
 
@@ -417,7 +417,7 @@
   --on-primary-container: var(--color-terracotta-800);
   --secondary-container: var(--color-parchment-200);
   --on-secondary-container: var(--color-night-1000);
-  --tertiary: var(--color-amber-500);
+  --tertiary: var(--color-amber-700);
   --tertiary-container: var(--color-amber-100);
   --on-tertiary-container: var(--color-amber-800);
   --error-container: var(--color-red-50);
@@ -501,7 +501,6 @@
   --elevation-nerd: 0 0 25px color-mix(in srgb, var(--accent-nerd) 15%, transparent), 0 12px 40px -12px color-mix(in srgb, var(--shadow-color) 12%, transparent);
   --elevation-nerd-hover: 0 0 35px color-mix(in srgb, var(--accent-nerd) 35%, transparent), 0 16px 48px -8px color-mix(in srgb, var(--shadow-color) 20%, transparent);
   --glow-chip-nerd: 0 0 12px color-mix(in srgb, var(--accent-nerd) 40%, transparent);
-  --glow-cta: 0 10px 22px color-mix(in srgb, var(--cta) 22%, transparent);
   --shadow-float: 0 8px 24px color-mix(in srgb, var(--shadow-color) 12%, transparent);
   /* Parametrica: var(--tone) si risolve sull'elemento che la consuma. */
   --glow-dot: 0 0 6px var(--tone);
@@ -564,7 +563,6 @@
   --elevation-confirm-action: 0 12px 28px color-mix(in srgb, var(--primary) 24%, transparent); /* bottone azione primary ConfirmDialog (ds) */
   --nav-dock-max-width: 352px; /* larghezza max capsula nav mobile (min con 92vw) */
   --search-overlay-panel-max-height: min(70vh, 560px); /* cap altezza pannello ricerca */
-  --search-overlay-drag-handle-height: 5px; /* maniglia drag mobile bottom-sheet */
   --drop-shadow-step-accent: drop-shadow(0 1px 2px color-mix(in srgb, var(--shadow-color) 24%, transparent)); /* stacco illustrazione step su fondo accent */
   --tip-popover-width: clamp(15rem, 65vw, 18.75rem); /* larghezza popover InfoTip (240–300px) */
 
@@ -610,7 +608,7 @@
   --text-default: var(--foreground);
   --text-muted: var(--muted-foreground);
   --text-subtle: var(--on-surface-variant);
-  --text-accent: var(--primary);
+  --text-accent: var(--color-terracotta-700);
   --text-success: var(--cta);
   --text-warning: var(--tertiary);
   --text-error: var(--destructive);
@@ -814,7 +812,6 @@
     color-mix(in srgb, var(--primary) 50%, transparent) 0%,
     transparent 65%
   );
-  --hero-brand-gradient: var(--grad-ember);
   --hero-mark-size: var(--space-40); /* logo mark container */
   --hero-glow-size: 26.25rem; /* 420px — diametro glow primario */
   --hero-glow-size-lg: 37.5rem; /* 600px — diametro glow secondario */
@@ -1017,7 +1014,8 @@
   --muted-foreground: var(--color-parchment-900);
   --accent: var(--color-night-500);
   --destructive: var(--color-red-400);
-  --destructive-foreground: var(--color-red-800);
+  --destructive-foreground: var(--color-night-1000);
+  --text-accent: var(--primary);
   --border: var(--color-night-200);
   --border-muted: var(--color-night-400);
 
@@ -1861,7 +1859,7 @@
   .explore-page__accent { transition: all 0.3s ease; }
   .explore-page__accent--nerd { background: var(--gradient-nerd); color: transparent; -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
   .explore-page__lead { max-width: var(--measure-sm); line-height: var(--leading-relaxed); margin-top: var(--space-3); }
-  .explore-filters { display: flex; gap: var(--gap-xs); margin-bottom: var(--space-8); overflow-x: auto; padding: var(--space-1); border-radius: var(--radius-2xl); background: color-mix(in srgb, var(--surface-container-low) 72%, transparent); border: var(--border-width-thin) solid var(--container-border-subtle); }
+  .explore-filters { display: flex; gap: var(--gap-xs); margin-bottom: var(--space-8); overflow-x: auto; padding: var(--space-1); border-radius: var(--radius-2xl); background: color-mix(in srgb, var(--surface-container-low) 72%, transparent); border: var(--border-width-thin) solid transparent; }
   .explore-filters__chip { display: flex; align-items: center; gap: var(--space-1-5); padding-inline: var(--space-4); padding-block: var(--space-2); border-radius: var(--radius-xl); flex-shrink: 0; background: var(--container-bg); color: var(--text-default); border: 1px solid var(--container-border); box-shadow: none; font-size: var(--font-size-lg); font-weight: var(--weight-semibold); cursor: pointer; outline: none; transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease; }
   .explore-filters__chip:hover { transform: translateY(calc(-1 * var(--space-px))); border-color: color-mix(in srgb, var(--primary) 28%, var(--container-border)); box-shadow: var(--shadow-sm); }
   .explore-filters__chip:focus-visible { outline: var(--space-0-5) solid color-mix(in srgb, var(--primary) 32%, transparent); outline-offset: var(--space-0-5); }
@@ -1925,6 +1923,7 @@
   .explore-card__badge--beginner { top: var(--space-3); left: var(--space-3); background: color-mix(in srgb, var(--cta) 90%, transparent); }
   .explore-card__match { position: absolute; top: var(--space-3); right: var(--space-3); }
   .explore-card__match-pill { display: flex; align-items: center; gap: var(--gap-2xs); padding-inline: var(--space-2); padding-block: var(--space-0-5); border-radius: var(--radius-full); color: white; background: color-mix(in srgb, var(--container-page) 82%, transparent); border: 1px solid color-mix(in srgb, var(--overlay-text) 12%, transparent); backdrop-filter: blur(var(--blur-md)); -webkit-backdrop-filter: blur(var(--blur-md)); font-size: var(--font-size-xs); font-weight: var(--weight-bold); box-shadow: var(--shadow-pill); }
+  .explore-card__match-icon { color: var(--cta); }
   .explore-card__match-mc { color: var(--cta); }
   .explore-card__match-arrow { color: var(--text-muted); opacity: 0.6; }
   .explore-card__match-headroom { color: var(--time-dayafter); }
@@ -2297,12 +2296,18 @@
 
   /* ── Onboarding card (WelcomeOnboardingCard) ── */
   .home-onboarding {
+    position: relative;
+    isolation: isolate;
     border-radius: var(--radius-2xl);
-    padding: var(--space-3-5) var(--space-4);
+    padding-block: var(--space-3-5);
+    padding-inline-start: var(--space-4);
+    padding-inline-end: var(--space-14);
     margin-bottom: var(--space-1);
     margin-top: var(--space-4);
-    background: color-mix(in srgb, var(--container-bg) 72%, transparent);
-    border: var(--border-width-thin) solid var(--container-border-subtle);
+    background: color-mix(in srgb, var(--container-page) 84%, transparent);
+    border: var(--blob-edge);
+    backdrop-filter: blur(var(--blur-md));
+    -webkit-backdrop-filter: blur(var(--blur-md));
   }
   .home-onboarding--session-active {
     margin-top: var(--space-20);
@@ -2349,6 +2354,27 @@
     font-size: var(--font-size-sm);
     text-decoration: underline;
     text-underline-offset: var(--space-0-75);
+  }
+  .home-onboarding__guide {
+    position: absolute;
+    top: calc(100% - var(--space-1));
+    left: var(--space-7);
+    width: var(--space-16);
+    height: var(--space-9);
+    color: var(--primary);
+    pointer-events: none;
+  }
+  .home-onboarding__guide-line {
+    position: absolute;
+    inset: var(--space-0) var(--space-4) var(--space-1) var(--space-0);
+    border-inline-start: var(--blob-edge);
+    border-block-end: var(--blob-edge);
+    border-end-start-radius: var(--radius-3xl);
+  }
+  .home-onboarding__guide svg {
+    position: absolute;
+    right: var(--space-0);
+    bottom: var(--space-0);
   }
 
   /* ── Override / CMS banners ── */
@@ -2504,6 +2530,9 @@
     }
   }
   .home-step__back {
+    position: sticky;
+    top: calc(var(--space-4) + env(safe-area-inset-top, 0px));
+    z-index: 60;
     transition: transform 150ms ease;
     color: var(--text-default);
     background: color-mix(in srgb, var(--container-bg) 85%, transparent);
@@ -2520,7 +2549,7 @@
     max-width: var(--measure-ml);
   }
   .home-step__title {
-    margin-top: var(--space-5);
+    margin-top: var(--space-7);
   }
   .home-step__subtitle {
     margin-top: var(--space-1);
@@ -2582,8 +2611,9 @@
     opacity: var(--home-glow-opacity, 0.06);
   }
   .home-hero__wordmark {
-    font-size: var(--font-size-sm);
-    letter-spacing: var(--tracking-colossal);
+    font-size: var(--font-size-md);
+    line-height: var(--leading-none);
+    letter-spacing: var(--tracking-wordmark);
     text-transform: uppercase;
     font-weight: var(--weight-bold);
     color: var(--primary);
@@ -2845,6 +2875,10 @@
 
   /* ── SavedRecipesSection ── */
   .profile-saved-recipes { display: flex; flex-direction: column; gap: var(--gap-xs); }
+  .profile-saved-recipes__empty { display: grid; justify-items: center; gap: var(--space-3); min-height: var(--space-60); padding: var(--space-6) var(--space-4); text-align: center; border-block: var(--border-width-thin) dashed var(--container-border-subtle); }
+  .profile-saved-recipes__empty-icon { display: grid; place-items: center; width: var(--space-12); height: var(--space-12); border-radius: var(--radius-full); color: var(--primary); background: color-mix(in srgb, var(--primary) 10%, transparent); box-shadow: 0 0 var(--space-4) color-mix(in srgb, var(--forge-glow) 22%, transparent); }
+  .profile-saved-recipes__empty-copy { display: grid; gap: var(--space-1); max-width: var(--measure-xs); }
+  .profile-saved-recipes__empty-copy p { color: var(--text-muted); font-size: var(--font-size-md); line-height: var(--leading-relaxed); }
   .profile-saved-recipes__item { position: relative; display: flex; align-items: center; border-radius: var(--radius-2xl); background: var(--surface-container-low); border: var(--border-width-thin) solid var(--outline-variant); }
   .profile-saved-recipes__link { display: flex; align-items: center; gap: var(--gap-sm); flex: 1; min-width: 0; padding-inline: var(--space-3-5); padding-block: var(--space-3); text-decoration: none; color: inherit; transition: transform 0.2s ease; }
   .profile-saved-recipes__link:active { transform: scale(0.99); }
@@ -2972,6 +3006,19 @@
   .profile-oven-temp__label { color: var(--text-muted); }
   .profile-oven-temp__value { font-size: var(--font-size-base); font-weight: var(--weight-semibold); color: var(--text-default); }
   .profile-oven-temp__slider { width: 100%; accent-color: var(--primary); }
+  .profile-oven-heat { margin-top: var(--space-5); display: flex; flex-direction: column; gap: var(--space-3); }
+  .profile-oven-heat__head { display: flex; align-items: baseline; justify-content: space-between; gap: var(--gap-sm); }
+  .profile-oven-heat__label { color: var(--text-default); font-weight: var(--weight-semibold); }
+  .profile-oven-heat__hint { color: var(--text-muted); text-align: right; }
+  .profile-oven-heat__grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--gap-xs); }
+  @media (max-width: 520px) { .profile-oven-heat__grid { grid-template-columns: 1fr; } }
+  .profile-oven-heat__option { min-width: 0; display: flex; flex-direction: column; gap: var(--space-1); padding: var(--space-3); border-radius: var(--radius-xl); border-width: var(--border-width-thin); border-style: solid; text-align: left; cursor: pointer; transition: transform 0.18s ease, box-shadow 0.18s ease; }
+  .profile-oven-heat__option:hover { box-shadow: var(--shadow-sm); }
+  .profile-oven-heat__option:active { transform: scale(0.98); }
+  .profile-oven-heat__option-row { display: flex; align-items: center; gap: var(--space-2); min-width: 0; }
+  .profile-oven-heat__option-label { color: var(--text-default); font-weight: var(--weight-semibold); }
+  .profile-oven-heat__option-badge { margin-left: auto; flex-shrink: 0; padding-inline: var(--space-1-5); padding-block: var(--space-0-5); border-radius: var(--radius-full); background: color-mix(in srgb, var(--primary) 12%, transparent); color: var(--primary); font-size: var(--font-size-2xs); font-weight: var(--weight-bold); text-transform: uppercase; letter-spacing: var(--tracking-caps); }
+  .profile-oven-heat__option-desc { color: var(--text-muted); line-height: var(--leading-normal); }
 
   /* ── Skill section (profile main) ── */
   .profile-skill-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--gap-xs); }
@@ -4151,6 +4198,16 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    height: min(100dvh, 100vh) !important;
+    max-height: min(100dvh, 100vh) !important;
+    border-radius: 0 !important;
+  }
+  @media (min-width: 640px) {
+    .setup-panel {
+      height: calc(100dvh - var(--space-8)) !important;
+      max-height: calc(100dvh - var(--space-8)) !important;
+      border-radius: var(--radius-4xl) !important;
+    }
   }
 
   /* ── Header ── */
@@ -4260,6 +4317,14 @@
   @media (min-width: 640px) {
     .setup-profile {
       padding: var(--space-5);
+    }
+  }
+  @media (min-width: 900px) {
+    .setup-profile {
+      display: grid;
+      grid-template-columns: minmax(220px, 0.34fr) minmax(0, 1fr);
+      align-items: start;
+      gap: var(--space-5);
     }
   }
 
@@ -4545,7 +4610,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--gap-2xs);
-    min-width: var(--space-16);
+    min-width: var(--space-21);
   }
 
   .setup-match__axis-row {
@@ -4575,9 +4640,24 @@
 
   .match-card {
     position: relative;
+    isolation: isolate;
     width: 100%;
+    padding-block: var(--space-4);
   }
-
+  .match-card::before {
+    content: "";
+    position: absolute;
+    z-index: 0;
+    inset: var(--space-0);
+    background: radial-gradient(ellipse at 82% 38%, color-mix(in srgb, var(--primary) 18%, transparent) 0%, color-mix(in srgb, var(--forge-glow) 8%, transparent) 36%, transparent 70%);
+    filter: blur(var(--blur-xl));
+    opacity: 0.7;
+    pointer-events: none;
+  }
+  .match-card > * {
+    position: relative;
+    z-index: 1;
+  }
   /* ── Kicker: icona + "Match" + filetto ── */
   .match-kicker {
     display: flex;
@@ -4666,6 +4746,9 @@
     color: var(--icon-muted);
     line-height: var(--leading-none);
     transition: color 0.15s ease, transform 0.15s ease;
+  }
+  .match-kicker .match-info-toggle {
+    margin-left: calc(var(--space-1) * -1);
   }
   .match-info-toggle:active {
     transform: scale(0.9);
@@ -4896,6 +4979,12 @@
     align-items: center;
     gap: var(--gap-sm);
   }
+  .match-action-cta,
+  .match-action-text {
+    box-sizing: border-box;
+    min-height: var(--space-9);
+    padding-block: var(--space-2);
+  }
   .match-action-cta {
     display: inline-flex;
     align-items: center;
@@ -4903,7 +4992,6 @@
     gap: var(--space-2);
     border-radius: var(--radius-full);
     padding-inline: var(--space-4);
-    padding-block: var(--space-2-5);
     background: var(--cta);
     color: var(--cta-foreground);
     border: none;
@@ -4911,7 +4999,6 @@
     font-size: var(--font-size-sm);
     font-weight: var(--weight-bold);
     line-height: var(--leading-tight);
-    box-shadow: var(--glow-cta);
   }
   .match-action-text {
     display: inline-flex;
@@ -4919,10 +5006,9 @@
     justify-content: center;
     gap: var(--space-1-5);
     border-radius: var(--radius-full);
-    padding-inline: var(--space-1);
-    padding-block: var(--space-2-5);
-    background: transparent;
-    border: none;
+    padding-inline: var(--space-3);
+    background: color-mix(in srgb, var(--container-bg) 76%, transparent);
+    border: var(--border-width-thin) solid var(--container-border-subtle);
     cursor: pointer;
     font-size: var(--font-size-sm);
     font-weight: var(--weight-semibold);
@@ -4941,7 +5027,7 @@
   /* ═══ ONDATA 3 — COMPONENT: ingredients-section (PREFIX: ingredients) ═══ */
   /* ═══ COMPONENT: ingredients-section ═══ */
 
-  /* ── Header: titolo + divisore + copia ── */
+  /* ── Header: titolo + divisore ── */
   .ingredients-header {
     display: flex;
     align-items: center;
@@ -4968,30 +5054,6 @@
     );
     opacity: 0.82;
   }
-  .ingredients-header__copy {
-    display: flex;
-    align-items: center;
-    gap: var(--space-1-5);
-    transition: color 0.15s;
-    padding-inline: var(--space-3);
-    padding-block: var(--space-1-5);
-    border-radius: var(--radius-full);
-    color: var(--text-muted);
-    font-weight: var(--weight-medium);
-    background: var(--recipe-bg);
-    border: var(--border-width-thin) solid var(--recipe-border);
-  }
-  .ingredients-header__copy:hover {
-    color: var(--primary);
-    border-color: color-mix(in srgb, var(--primary) 28%, var(--recipe-border));
-  }
-  .ingredients-header__copy:active {
-    transform: scale(0.95);
-  }
-  .ingredients-header__copy-icon {
-    color: var(--recipe-success);
-  }
-
   /* ── Riga panetti/servings ── */
   .ingredients-servings {
     display: flex;
@@ -5000,7 +5062,6 @@
     gap: var(--space-3) var(--space-4);
     margin-bottom: var(--space-5);
     padding-bottom: var(--space-4);
-    border-bottom: var(--border-width-thin) solid var(--recipe-divider-subtle);
   }
   .ingredients-servings__label {
     color: var(--text-muted);
@@ -5093,16 +5154,27 @@
 
   /* ── Totale impasto ── */
   .ingredients-total {
+    display: flex;
+    align-items: baseline;
+    justify-content: flex-end;
+    gap: var(--space-1-5);
     margin-top: var(--space-5);
+    color: var(--text-default);
+    font-size: var(--font-size-2xl);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-tight);
+  }
+  .ingredients-total__label {
     color: var(--text-muted);
-    font-size: var(--font-size-xl);
+    font-size: var(--font-size-md);
+    font-weight: var(--weight-medium);
   }
 
   /* ── Scorporo pre-fermento (biga/poolish) ── */
   .ingredients-preferment {
     margin-top: var(--space-5);
     border-radius: var(--radius-2xl);
-    overflow: hidden;
+    overflow: clip;
     border: var(--border-width-thin) solid var(--outline-variant);
   }
   .ingredients-preferment__grid {
@@ -5138,6 +5210,9 @@
     color: var(--text-muted);
     border-top: var(--border-width-thin) solid var(--outline-variant);
     line-height: var(--leading-comfortable);
+    padding-inline: var(--space-5);
+    padding-block: var(--space-2-5);
+    background: color-mix(in srgb, var(--container-bg-low) 55%, transparent);
   }
 
   /* ── Blocco scienza (PizzaNerd) ── */
@@ -5646,15 +5721,18 @@
   }
 
   .procedure-hero__time-input {
-    background: transparent;
+    background: var(--recipe-bg);
     text-align: center;
     outline: none;
     color: var(--text-default);
-    font-size: clamp(var(--font-size-md), 3.7vw, var(--font-size-2xl));
+    font-size: var(--font-size-md);
     font-weight: var(--weight-bold);
-    width: 58px;
-    border: none;
-    border-bottom: var(--border-width-strong) solid var(--recipe-highlight);
+    width: 100%;
+    min-height: var(--space-9);
+    border-radius: var(--radius-lg);
+    border: var(--border-width-thin) solid var(--recipe-highlight);
+    padding-inline: var(--space-2);
+    color-scheme: light dark;
   }
 
   .procedure-hero__time-display {
@@ -5672,10 +5750,38 @@
   }
 
   .procedure-hero__time-value {
-    font-size: clamp(var(--font-size-md), 3.7vw, var(--font-size-2xl));
+    font-size: clamp(var(--font-size-md), 3vw, var(--font-size-2xl));
     font-weight: var(--weight-bold);
     line-height: var(--leading-tight);
     color: var(--text-accent);
+  }
+
+  .procedure-hero__native-picker {
+    margin-top: var(--space-2);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-1-5);
+    width: 100%;
+    padding-inline: var(--space-2);
+    padding-block: var(--space-1-5);
+    border-radius: var(--radius-full);
+    border: var(--border-width-thin) solid var(--container-border-subtle);
+    background: color-mix(in srgb, var(--container-bg) 72%, transparent);
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-tight);
+    cursor: pointer;
+    transition: transform 150ms ease, color 150ms ease, border-color 150ms ease, background 150ms ease;
+  }
+  .procedure-hero__native-picker:hover {
+    color: var(--text-default);
+    border-color: color-mix(in srgb, var(--primary) 24%, var(--container-border));
+    background: var(--container-bg);
+  }
+  .procedure-hero__native-picker:active {
+    transform: scale(0.97);
   }
 
   .procedure-hero__time-suffix {
@@ -6597,21 +6703,20 @@
     position: fixed;
     top: calc(var(--space-4) + env(safe-area-inset-top, 0px));
     left: var(--space-4);
-    z-index: 50;
+    z-index: calc(var(--z-widget) - 10);
     pointer-events: auto;
   }
-  .recipe-view-back--hidden { pointer-events: none; }
 
   .recipe-view-back__button {
-    background: color-mix(in srgb, var(--container-page) 94%, transparent);
-    backdrop-filter: blur(var(--blur-md));
-    -webkit-backdrop-filter: blur(var(--blur-md));
+    background: var(--premium-glass-bg);
+    backdrop-filter: blur(var(--blur-dock-glass)) saturate(1.8);
+    -webkit-backdrop-filter: blur(var(--blur-dock-glass)) saturate(1.8);
     color: var(--text-default);
-    border: var(--border-width-thin) solid color-mix(in srgb, var(--primary) 28%, var(--container-border));
-    box-shadow: var(--shadow-float);
+    border: var(--border-width-thin) solid var(--premium-glass-border);
+    box-shadow: var(--premium-glass-shadow);
     transition: transform 0.15s, background 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
-  .recipe-view-back__button:hover { background: var(--container-bg); border-color: color-mix(in srgb, var(--primary) 45%, var(--container-border)); box-shadow: var(--shadow-float), var(--shadow-glow); }
+  .recipe-view-back__button:hover { background: color-mix(in srgb, var(--container-page) 94%, transparent); border-color: color-mix(in srgb, var(--text-default) 14%, transparent); box-shadow: var(--premium-glass-shadow); }
   .recipe-view-back__button:active { transform: scale(0.9); }
 
   /* ── Hero photo ── */
@@ -6793,14 +6898,12 @@
     letter-spacing: var(--tracking-spread);
     line-height: var(--leading-normal);
   }
-
-  .recipe-view-utility-row {
+  .recipe-view-meta-row {
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
-    column-gap: var(--gap-lg);
+    align-items: baseline;
+    column-gap: var(--gap-sm);
     row-gap: var(--gap-xs);
-    /* Utilità, non contenuto: corpo minore. */
     font-size: clamp(var(--font-size-md), 3vw, var(--font-size-lg));
     margin: 0;
   }
@@ -6834,7 +6937,6 @@
     grid-template-columns: repeat(4, minmax(0, 1fr));
     padding-top: var(--space-3-5); /* 14px */
     padding-bottom: var(--space-1); /* 4px */
-    border-top: var(--border-width-thin) solid var(--container-border-subtle);
   }
 
   .stat-strip__cell {
@@ -6934,16 +7036,35 @@
 
   /* ── Switcher (riga chip) ── */
   .interpretation-switcher {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "label label"
+      "scroll more";
     align-items: center;
-    gap: var(--gap-xs);
+    column-gap: var(--gap-xs);
+    row-gap: var(--space-0-5);
     padding: var(--space-1);
     border-radius: var(--radius-2xl);
     background: color-mix(in srgb, var(--surface-container-low) 74%, transparent);
     border: var(--border-width-thin) solid var(--container-border-subtle);
+    overflow: visible;
+  }
+
+  .interpretation-switcher__label {
+    grid-area: label;
+    flex-shrink: 0;
+    padding-inline: var(--space-1);
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-tight);
+    text-transform: uppercase;
+    letter-spacing: 0;
   }
 
   .interpretation-switcher__scroll {
+    grid-area: scroll;
     flex: 1 1 0%;
     min-width: 0;
     display: flex;
@@ -6951,16 +7072,29 @@
     gap: var(--gap-xs);
     overflow-x: auto;
     padding-inline: var(--space-0-5);
+    padding-block: var(--space-1);
     margin-inline: calc(var(--space-0-5) * -1);
+    margin-block: calc(var(--space-1) * -1);
     scrollbar-width: none;
+    -webkit-mask-image: linear-gradient(to right, var(--color-black) 0%, var(--color-black) calc(100% - var(--space-7)), transparent 100%);
+    mask-image: linear-gradient(to right, var(--color-black) 0%, var(--color-black) calc(100% - var(--space-7)), transparent 100%);
+  }
+  .interpretation-switcher__more {
+    grid-area: more;
   }
   @media (min-width: 768px) {
     .interpretation-switcher {
+      display: flex;
       padding: var(--space-1-5);
       box-shadow: inset 0 0 0 var(--border-width-thin) color-mix(in srgb, var(--overlay-text) 4%, transparent);
     }
+    .interpretation-switcher__label {
+      padding-inline: var(--space-2);
+    }
     .interpretation-switcher__scroll {
       gap: var(--space-1-5);
+      -webkit-mask-image: none;
+      mask-image: none;
     }
   }
 
@@ -7015,6 +7149,14 @@
     line-height: var(--leading-tight);
     cursor: pointer;
     transition: all 0.15s ease;
+  }
+  .interpretation-switcher__more:hover,
+  .interpretation-switcher__more:focus-visible {
+    color: var(--text-default);
+    background: var(--container-bg);
+    border-color: color-mix(in srgb, var(--primary) 24%, var(--container-border));
+    box-shadow: var(--shadow-xs);
+    transform: translateY(calc(-1 * var(--space-px)));
   }
   .interpretation-switcher__more:active {
     transform: scale(0.95);
@@ -8944,9 +9086,13 @@
   top: var(--space-3);
   right: calc(var(--space-3) + var(--space-10) + var(--space-0-5));
   z-index: 3;
+}
+.style-detail-sheet__close-btn,
+.style-detail-sheet__fav-btn {
   background: var(--surface-container);
-  color: var(--text-muted);
+  color: var(--text-default);
   border: 1px solid var(--outline-variant);
+  box-shadow: var(--shadow-sm);
 }
 .style-detail-sheet__fav-btn--active {
   background: color-mix(in srgb, var(--primary) 14%, var(--surface-container));
@@ -9028,6 +9174,9 @@
   color: var(--text-muted);
 }
 .style-detail-title__match {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
   padding-inline: var(--space-1-5);
   padding-block: var(--space-0-5);
   border-radius: var(--radius-md);
@@ -9483,15 +9632,6 @@
   border: var(--border-width-thin) solid var(--container-border-subtle);
 }
 
-/* ── "Non fattibili" explainer note ── */
-.recommended-tier-note {
-  margin-bottom: var(--space-4);
-  font-style: italic;
-  font-size: var(--font-size-sm);
-  color: var(--text-muted);
-  line-height: var(--leading-relaxed);
-}
-
 /* ── Collection grid ── */
 .recommended-collection {
   display: grid;
@@ -9603,14 +9743,15 @@
   /* min(…, cqw): nelle colonne strette il titolo scala con la card —
      "Contemporanea" non si spezza né viene clippato. */
   font-size: min(clamp(var(--font-size-3xl), 3.5vw, var(--font-size-6-5xl)), 10.5cqw);
-  hyphens: auto;
-  overflow-wrap: break-word;
+  hyphens: none;
+  overflow-wrap: normal;
+  word-break: normal;
   font-weight: var(--weight-bold);
   line-height: var(--leading-snug);
   color: var(--overlay-text);
   text-shadow: var(--overlay-shadow-text);
   display: block;
-  letter-spacing: var(--tracking-snug);
+  letter-spacing: 0;
 }
 .recommended-card__subtitle {
   margin-top: var(--space-1-5);
@@ -9721,8 +9862,8 @@
 
 .section-tabs-wrap--sticky {
   position: sticky;
-  z-index: 30;
-  top: var(--section-tabs-sticky-top, var(--space-11));
+  z-index: 45;
+  top: calc(var(--section-tabs-sticky-top, var(--space-11)) + env(safe-area-inset-top, 0px));
 }
 
 .section-tabs-wrap--navbar {
@@ -10693,7 +10834,7 @@
     position: relative;
     flex: 1 1 0%;
     overflow: hidden;
-    background: color-mix(in srgb, var(--container-page) 94%, transparent);
+    background: var(--premium-glass-bg);
     backdrop-filter: blur(var(--blur-dock-glass)) saturate(1.8);
     -webkit-backdrop-filter: blur(var(--blur-dock-glass)) saturate(1.8);
     border: var(--border-width-thin) solid var(--premium-glass-border);
@@ -10701,8 +10842,11 @@
     border-radius: var(--radius-2xl);
   }
   .app-shell-dock--scrolled .app-shell-dock__nav {
-    background: color-mix(in srgb, var(--container-page) 88%, transparent);
+    background: color-mix(in srgb, var(--container-page) 94%, transparent);
     box-shadow: var(--premium-glass-shadow), 0 0 0 var(--border-width-thin) color-mix(in srgb, var(--overlay-text) 5%, transparent);
+  }
+  .app-shell-dock--hidden {
+    pointer-events: none;
   }
 
   .app-shell-dock__gloss {
@@ -10775,16 +10919,48 @@
   }
 
   .app-shell-rail__logo {
+    position: relative;
+    isolation: isolate;
     display: flex;
     align-items: center;
     justify-content: center;
     margin-bottom: var(--space-5);
     width: var(--space-10);
     height: var(--space-10);
-    border-radius: var(--radius-md);
-    background: var(--hero-brand-gradient);
-    color: var(--overlay-text);
+    color: var(--primary);
     transition: transform 150ms ease;
+  }
+
+  .app-shell-rail__logo::before {
+    content: "";
+    position: absolute;
+    z-index: 0;
+    left: 50%;
+    top: 50%;
+    width: var(--space-12);
+    height: var(--space-12);
+    border-radius: var(--radius-full);
+    background: radial-gradient(ellipse at center, color-mix(in srgb, var(--primary) 18%, transparent) 0%, color-mix(in srgb, var(--forge-glow) 8%, transparent) 42%, transparent 72%);
+    filter: blur(var(--blur-md));
+    pointer-events: none;
+    transform: translate(-51%, -49%);
+    will-change: transform;
+    animation: app-shell-logo-drift 12s ease-in-out infinite;
+  }
+
+  @keyframes app-shell-logo-drift {
+    0%, 100% { transform: translate(-51%, -49%); }
+    38% { transform: translate(-48%, -52%); }
+    72% { transform: translate(-52%, -47%); }
+  }
+
+  .app-shell-rail__logo > svg {
+    position: relative;
+    z-index: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .app-shell-rail__logo::before { animation: none; }
   }
 
   .app-shell-rail__logo:active {
@@ -10795,9 +10971,15 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     gap: var(--space-1-5);
-    flex: 1 1 0%;
+    flex: 0 0 auto;
+  }
+
+  .app-shell-rail__search {
+    margin-top: var(--space-3);
+    padding-top: var(--space-3);
+    border-top: var(--border-width-thin) solid var(--container-border-subtle);
   }
 
   .app-shell-rail__dev {
@@ -10992,22 +11174,6 @@
   }
   .search-overlay-x__panel--mobile {
     transform-origin: bottom center;
-  }
-
-  .search-overlay-x__drag-wrap {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding-top: var(--space-3);
-    padding-bottom: var(--space-1);
-    flex-shrink: 0;
-  }
-  .search-overlay-x__drag-handle {
-    border-radius: var(--radius-full);
-    width: var(--space-9);
-    height: var(--search-overlay-drag-handle-height);
-    background: var(--container-border);
-    opacity: 0.4;
   }
 
   .search-overlay-x__input-row {
@@ -11376,6 +11542,7 @@
     align-items: center;
     justify-content: center;
     will-change: transform;
+    color: var(--overlay-text);
   }
 
   /* ── vulcan-logo ── */
@@ -12763,7 +12930,11 @@
     cursor: pointer;
     font-size: var(--chip-font-size);
     font-weight: var(--chip-weight-active);
-    transition: transform 0.2s ease;
+    transition: transform 0.2s ease, background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+  }
+
+  .ds-filterchip:hover {
+    box-shadow: var(--shadow-xs);
   }
 
   .ds-filterchip:active {
@@ -12774,6 +12945,7 @@
     background: var(--chip-bg-active);
     color: var(--chip-text-active);
     border-color: transparent;
+    box-shadow: var(--shadow-xs);
   }
 
   .ds-filterchip--sm {
@@ -12973,7 +13145,7 @@
   --font-mono-family: "DM Mono", monospace;
 }
 [data-theme="vulcan"]:not(.dark) {
-  --primary: var(--color-terracotta-500);
+  --primary: var(--color-terracotta-600);
 }
 
 /* ── RISERVA — Newsreader × DM Sans ──
@@ -13044,6 +13216,7 @@
   --tertiary: #b8813d;
   --tertiary-container: #f4e6cc;
   --on-tertiary-container: #6b4a1d;
+  --text-warning: var(--on-tertiary-container);
   --grad-ember: linear-gradient(135deg, #c2401f 0%, #d4652f 55%, #cb8a3e 100%);
   --grad-warm: linear-gradient(160deg, #faf6ee 0%, #f9ede2 55%, #f4e6cc 100%);
 }
@@ -13195,6 +13368,7 @@
   --tertiary: #b97d0c;
   --tertiary-container: #f2e3bd;
   --on-tertiary-container: #5d3f06;
+  --text-warning: var(--on-tertiary-container);
   --inverse-surface: #211f1d;
   --inverse-on-surface: #f4f2ec;
   --cta: #2c7a4b;
@@ -13337,6 +13511,7 @@
   --tertiary: #a97f2f;
   --tertiary-container: #f4e8cd;
   --on-tertiary-container: #5c421a;
+  --text-warning: var(--on-tertiary-container);
   --inverse-surface: #1c1b1a;
   --inverse-on-surface: #f7f6f4;
   --cta: #121110;


### PR DESCRIPTION
## What changed

This addresses the client-side annotation batch that was present in the pasted client prompt but not in the synced D1 annotation registry.

- Updated recipe result UI: stat strip optimized-value treatment, interpretation switcher visibility, setup version selector, removed temporary share action, and clearer match/back affordances.
- Improved recipe ingredient/procedure surfaces: pre-ferment amount notes, day suffixes on start/end controls, less fake precision in timeline times and durations.
- Reworked profile into tabs for setup, app preferences, and saved recipes.
- Tuned Explore filters/card copy and line breaking, including replacing author copy from “via” to “Secondo/secondo”.
- Adjusted home footer/bottom nav behavior and recommended-style ranking/clear controls.

## Why

The remote annotation DB showed all live annotations as resolved, but the client prompt contained a larger local batch (#8–#28). These changes implement that missing local client batch so the UI matches the annotated feedback.

## Impact

The affected surfaces are `/`, `/profile`, `/explore`, and `/recipe/napoletana_canotto`. Changes are visual/interaction focused and keep recipe engine internals intact, except for display-only rounding of procedure durations.

## Validation

- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npm run verify`
- Browser QA via Playwright on `/profile`, `/explore`, `/`, and `/recipe/napoletana_canotto`

Notes: browser QA showed only the existing `motion() is deprecated` warning; no console errors.