### PR TITLE
feat(theme): Sfornata — nuovo tema di default (l'ora del forno)

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,17 +25,21 @@
               window.matchMedia("(prefers-color-scheme: dark)").matches);
           var el = document.documentElement;
           if (dark) el.classList.add("dark");
-          /* Tema rivista di cucina scelto (fase esplorativa): applicato prima
-             del primo paint per evitare il flash del tema di default.
+          /* Tema applicato prima del primo paint per evitare il flash.
+             Default: SFORNATA (promosso); "vulcan" resta l'originale.
              ?theme=… nell'URL vince e viene persistito (deep-link condivisibile). */
           var qTheme = new URLSearchParams(window.location.search).get("theme");
           if (qTheme !== null) {
             localStorage.setItem("vulcan_theme", qTheme);
           }
           var theme = qTheme !== null ? qTheme : localStorage.getItem("vulcan_theme");
-          if (theme) el.setAttribute("data-theme", theme);
+          if (!theme) theme = "sfornata";
+          el.setAttribute("data-theme", theme);
           /* Colore diretto: copre il gap prima che theme.css sia caricato. */
-          el.style.backgroundColor = dark ? "#131211" : "#fdfbf7";
+          var sfor = theme === "sfornata";
+          el.style.backgroundColor = dark
+            ? (sfor ? "#171009" : "#131211")
+            : (sfor ? "#fdfaf4" : "#fdfbf7");
         } catch (e) {
           /* storage inaccessibile: resta il default chiaro */
         }

--- a/src/app/features/dev-tools/theme-switcher.tsx
+++ b/src/app/features/dev-tools/theme-switcher.tsx
@@ -20,14 +20,15 @@ export interface ThemeMeta {
 }
 
 export const THEMES: ThemeMeta[] = [
-  { id: "", preview: "vulcan", label: "Vulcan", note: "L'originale · Playfair" },
-  { id: "sfornata", preview: "sfornata", label: "Sfornata", note: "L'ora del forno · Playfair" },
+  { id: "", preview: "sfornata", label: "Sfornata", note: "Il default · L'ora del forno" },
+  { id: "vulcan", preview: "vulcan", label: "Vulcan", note: "L'originale · Playfair" },
 ];
 
+/* Sfornata è il tema promosso: la non-scelta (id "") lo applica. "vulcan"
+   resta l'originale (alias che eredita i token di :root). Un id legacy di
+   un tema rimosso non matcha nessun blocco CSS → rende come l'originale. */
 function applyTheme(id: string) {
-  const el = document.documentElement;
-  if (id) el.dataset.theme = id;
-  else delete el.dataset.theme;
+  document.documentElement.dataset.theme = id || "sfornata";
 }
 
 function readStr(key: string, fallback: string): string {


### PR DESCRIPTION
## Cosa cambia

**Sfornata** — il tema "l'ora del forno" uscito vincitore dal confronto giudicato sui pixel contro l'originale (3/3 giudici) — viene **promosso a tema di default**. "Vulcan" (l'originale) resta selezionabile dal picker in Profilo.

### Il tema
- **Zero font-swap**: Playfair Display, DM Sans e DM Mono restano l'identità tipografica.
- **Explore = copertina** (mobile): featured card con foto full-bleed `min(64vh, 480px)`, titolo Playfair *sulla* fotografia, velo espresso che sale dal basso; feed a colonna singola.
- **Ricetta**: hero full-bleed che si scioglie nella carta via `var(--container-page)`; i numeri dello spec-sheet in serif da ricettario, con le etichette che non troncano più ("FORZA FARINA" intera) e il contesto ("ambiente") a capo.
- **Crea**: masthead a scala editoriale, glow-forno ingrandito e approfondito, ore degli slot in serif.
- **Carta bianca appena tiepida** (#fdfaf4): il calore vive negli accenti, glow e veli — non nel fondo.
- **Dark "sala col forno acceso"**: espresso ambrato, riflesso di candela sulle superfici elevate, basilico profondo sui CTA.
- CTA verdi e codici semantici (oro=consiglio, terracotta=selezione) intoccati.

### Promozione a default
- `index.html` (anti-FOUC): la non-scelta risolve a `data-theme="sfornata"`, colore di pre-paint per tema; `?theme=vulcan` deep-linka l'originale.
- `theme-switcher.tsx`: lineup a due — Sfornata (default) + Vulcan (originale); gli id legacy dei temi rimossi degradano all'originale.
- Temi esplorativi rimossi (Riserva/Lettera/Copertina + ondate precedenti già eliminate); font extra tolti dal bundle (`fonts.css` torna a 3 famiglie).

### Verifica
- `npm run verify` verde (tsc, check:tokens, check:semantics, Vitest).
- QA visivo headless 375px, light+dark, su Crea/Scopri/Ricetta/Profilo; confronto side-by-side default-vs-vulcan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)