### PR TITLE
revert(theme): Vulcan resta il tema di default

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,21 +25,17 @@
               window.matchMedia("(prefers-color-scheme: dark)").matches);
           var el = document.documentElement;
           if (dark) el.classList.add("dark");
-          /* Tema applicato prima del primo paint per evitare il flash.
-             Default: SFORNATA (promosso); "vulcan" resta l'originale.
+          /* Tema rivista di cucina scelto (fase esplorativa): applicato prima
+             del primo paint per evitare il flash del tema di default.
              ?theme=… nell'URL vince e viene persistito (deep-link condivisibile). */
           var qTheme = new URLSearchParams(window.location.search).get("theme");
           if (qTheme !== null) {
             localStorage.setItem("vulcan_theme", qTheme);
           }
           var theme = qTheme !== null ? qTheme : localStorage.getItem("vulcan_theme");
-          if (!theme) theme = "sfornata";
-          el.setAttribute("data-theme", theme);
+          if (theme) el.setAttribute("data-theme", theme);
           /* Colore diretto: copre il gap prima che theme.css sia caricato. */
-          var sfor = theme === "sfornata";
-          el.style.backgroundColor = dark
-            ? (sfor ? "#171009" : "#131211")
-            : (sfor ? "#fdfaf4" : "#fdfbf7");
+          el.style.backgroundColor = dark ? "#131211" : "#fdfbf7";
         } catch (e) {
           /* storage inaccessibile: resta il default chiaro */
         }

--- a/src/app/features/dev-tools/theme-switcher.tsx
+++ b/src/app/features/dev-tools/theme-switcher.tsx
@@ -20,15 +20,14 @@ export interface ThemeMeta {
 }
 
 export const THEMES: ThemeMeta[] = [
-  { id: "", preview: "sfornata", label: "Sfornata", note: "Il default · L'ora del forno" },
-  { id: "vulcan", preview: "vulcan", label: "Vulcan", note: "L'originale · Playfair" },
+  { id: "", preview: "vulcan", label: "Vulcan", note: "L'originale · Playfair" },
+  { id: "sfornata", preview: "sfornata", label: "Sfornata", note: "L'ora del forno · Playfair" },
 ];
 
-/* Sfornata è il tema promosso: la non-scelta (id "") lo applica. "vulcan"
-   resta l'originale (alias che eredita i token di :root). Un id legacy di
-   un tema rimosso non matcha nessun blocco CSS → rende come l'originale. */
 function applyTheme(id: string) {
-  document.documentElement.dataset.theme = id || "sfornata";
+  const el = document.documentElement;
+  if (id) el.dataset.theme = id;
+  else delete el.dataset.theme;
 }
 
 function readStr(key: string, fallback: string): string {


### PR DESCRIPTION
Ripensamento sul default: **Vulcan (l'originale) resta il tema di default**; Sfornata rimane disponibile nel picker dei temi (Profilo → Tema) e via deep-link `?theme=sfornata`.

Revert puntuale di 0925e48 (entrato in main col merge della #41 prima che il revert arrivasse sul branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)