### PR TITLE
fix(recipe): risolvi annotazioni debug UI (match-card, sticky tabs, scoring, picker)

### DIFF
--- a/src/app/features/recipe/procedure-hero.tsx
+++ b/src/app/features/recipe/procedure-hero.tsx
@@ -103,6 +103,7 @@ export function ProcedureHeroControls({
               onClick={() => setStartTime((s) => shiftQuarter(s, -1))}
               className="procedure-hero__shift-btn"
               aria-label={ui.ariaEarlier}
+              title={ui.ariaEarlier}
             >
               <Minus size={13} />
             </button>
@@ -124,6 +125,15 @@ export function ProcedureHeroControls({
             ) : (
               <button
                 onClick={() => setEditingTime(true)}
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    setStartTime((s) => shiftQuarter(s, 1));
+                  } else if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    setStartTime((s) => shiftQuarter(s, -1));
+                  }
+                }}
                 className="procedure-hero__time-display type-numeric"
               >
                 <span className="procedure-hero__time-value">
@@ -138,6 +148,7 @@ export function ProcedureHeroControls({
               onClick={() => setStartTime((s) => shiftQuarter(s, 1))}
               className="procedure-hero__shift-btn"
               aria-label={ui.ariaLater}
+              title={ui.ariaLater}
             >
               <Plus size={13} />
             </button>
@@ -164,6 +175,7 @@ export function ProcedureHeroControls({
               onClick={() => setStartTime((s) => shiftQuarter(s, -1))}
               className="procedure-hero__shift-btn"
               aria-label={ui.ariaEarlier}
+              title={ui.ariaEarlier}
             >
               <Minus size={13} />
             </button>
@@ -185,6 +197,15 @@ export function ProcedureHeroControls({
             ) : (
               <button
                 onClick={() => setEditingEndTime(true)}
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    setStartTime((s) => shiftQuarter(s, 1));
+                  } else if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    setStartTime((s) => shiftQuarter(s, -1));
+                  }
+                }}
                 className="procedure-hero__time-display type-numeric"
               >
                 <span className="procedure-hero__time-value">
@@ -200,6 +221,7 @@ export function ProcedureHeroControls({
               onClick={() => setStartTime((s) => shiftQuarter(s, 1))}
               className="procedure-hero__shift-btn"
               aria-label={ui.ariaLater}
+              title={ui.ariaLater}
             >
               <Plus size={13} />
             </button>

--- a/src/app/features/recipe/recipe-match-card.tsx
+++ b/src/app/features/recipe/recipe-match-card.tsx
@@ -311,6 +311,7 @@ export function RecipeMatchCard({
       className={`match-card ${className}`}
       aria-label={cms.ui.recipeScore}
     >
+      <div className="match-card__main">
       {/* ═══ Verdetto editoriale (redesign lug 2026, round 5) ═══
           Il Match È un verdetto da guida gastronomica: punteggio in serifa,
           tono in corsivo — "85/100 · Ottima intesa" come su una guida.
@@ -528,6 +529,7 @@ export function RecipeMatchCard({
           </motion.div>
         )}
       </AnimatePresence>
+      </div>
 
       <div className="match-actions">
         {onOptimize && (

--- a/src/app/features/recipe/recipe-view.tsx
+++ b/src/app/features/recipe/recipe-view.tsx
@@ -456,28 +456,31 @@ export function RecipeView({
       {/* ── Contenuto ── */}
       <div data-region="body" id="recipe-content-tabs-anchor" className="recipe-view-body">
         <div className="recipe-view-content">
+          {/* Le section-tabs stanno FUORI dal wrapper animato: un antenato con
+              `transform` (l'entry motion.div) diventa il containing block e
+              rompe `position: sticky` — le tabs non si agganciavano più
+              (pin VPL-149713). Qui restano figlie dirette di recipe-view-content. */}
+          {!isMobile && (
+            <RecipeSectionTabs
+              variant="inline"
+              activeTab={activeTab}
+              recipeLabel={recipeTabLabel}
+              onChange={onTabChange}
+              fillingMode={isFillingStyle(recipe.style)}
+              /* VPL-A3: senza sticky header restano i controlli flottanti
+               * (back + Inizia) a top-4 / h-10 → bottom ~56px. Il pill sticky
+               * (z-30, sotto i controlli z-50) deve fissarsi sotto di essi per
+               * non finirgli sotto sui bordi a larghezza tablet. */
+              stickyTop={showStickyHeader ? 56 : 64}
+              procedureSubtitle={procedureSubtitle}
+              toppingSubtitle={toppingSubtitle}
+            />
+          )}
           <motion.div
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ type: "spring", stiffness: 400, damping: 30, delay: 0.08 }}
           >
-            {!isMobile && (
-              <RecipeSectionTabs
-                variant="inline"
-                activeTab={activeTab}
-                recipeLabel={recipeTabLabel}
-                onChange={onTabChange}
-                fillingMode={isFillingStyle(recipe.style)}
-                /* VPL-A3: senza sticky header restano i controlli flottanti
-                 * (back + Inizia) a top-4 / h-10 → bottom ~56px. Il pill sticky
-                 * (z-30, sotto i controlli z-50) deve fissarsi sotto di essi per
-                 * non finirgli sotto sui bordi a larghezza tablet. */
-                stickyTop={showStickyHeader ? 56 : 64}
-                procedureSubtitle={procedureSubtitle}
-                toppingSubtitle={toppingSubtitle}
-              />
-            )}
-
             <RecipeOutput
               recipe={recipe}
               constraints={constraints}

--- a/src/app/features/recipe/recommended-styles.tsx
+++ b/src/app/features/recipe/recommended-styles.tsx
@@ -1,6 +1,6 @@
 import { Award,Check,ChefHat,Clock,Flame,Search,SlidersHorizontal,Sparkles,Triangle,Wheat,X } from "lucide-react";
-import { AnimatePresence,motion } from "motion/react";
-import { useMemo,useState } from "react";
+import { AnimatePresence,motion,useAnimationControls,useReducedMotion } from "motion/react";
+import { useEffect,useMemo,useRef,useState } from "react";
 import { useCms } from "../cms/cms-context";
 import { createFormatter,formatTemperatureCopy,t } from "../cms/i18n";
 import { FilterChip, Surface } from "../../components/ds/index";
@@ -295,6 +295,25 @@ export function RecommendedStyles({
 
   let idx = 0;
 
+  /* Feedback di ricalcolo (nota Matteo): quando cambi un vincolo, i risultati
+   * qui sotto si aggiornano in place (card riconciliate per id) senza segnale
+   * visivo. Un pulse gentile sul blocco risultati comunica "ho ricalcolato". */
+  const reduceMotion = useReducedMotion();
+  const resultsControls = useAnimationControls();
+  const firstResultsRun = useRef(true);
+  useEffect(() => {
+    if (firstResultsRun.current) {
+      firstResultsRun.current = false;
+      return;
+    }
+    if (reduceMotion) return;
+    resultsControls.start({
+      opacity: [0.72, 1],
+      y: [4, 0],
+      transition: { duration: 0.34, ease: "easeOut" },
+    });
+  }, [recommendations, resultsControls, reduceMotion]);
+
   const handleSelect = (rec: RecommendationWithVariant) => {
     onSelectStyle(rec.style, rec.bestInterpretation);
   };
@@ -447,6 +466,7 @@ export function RecommendedStyles({
       </AnimatePresence>
 
       {/* ═══ Tier groups ═══ */}
+      <motion.div className="recommended-styles__results" animate={resultsControls}>
       {tiers.length === 0 && (
         <Surface
           as={motion.div}
@@ -544,6 +564,7 @@ export function RecommendedStyles({
           </motion.div>
         );
       })}
+      </motion.div>
     </div>
   );
 }
@@ -664,6 +685,7 @@ function StyleCard({
             <div className="recommended-card__score">
               <ScoreRing
                 score={displayScore}
+                baseScore={compatibilityScore}
                 color={ringColor}
                 size={38}
               />

--- a/src/app/features/recipe/score-ring.tsx
+++ b/src/app/features/recipe/score-ring.tsx
@@ -2,18 +2,33 @@
  * ScoreRing — Circular score badge (SVG).
  * Extracted from recommended-styles.tsx for DRY (VPL-006).
  * Uses Tier 3 tokens: --score-ring-track, --score-ring-track-stroke, --score-ring-text.
+ *
+ * Compromesso scoring (nota Matteo, pin VPL-059548): quando è noto il punteggio
+ * di PARTENZA (compatibilità out-of-the-box) oltre a quello OTTIMIZZATO, l'anello
+ * lo racconta senza perdere l'estetica — segmento pieno = partenza, estensione
+ * soft-glow = il salto guadagnato ottimizzando; il numero al centro resta
+ * l'ottimizzato. Senza `baseScore` il comportamento è identico a prima (usato
+ * anche dai 5 assi del composite, dove il concetto partenza→ottimizzata non vale).
  */
-
 interface ScoreRingProps {
   score: number;
   color: string;
   size?: number;
+  /** Punteggio di partenza (pre-ottimizzazione). Se < score, l'anello mostra
+   *  il salto partenza→ottimizzata come estensione soft dello stesso colore. */
+  baseScore?: number;
 }
 
-export function ScoreRing({ score, color, size = 36 }: ScoreRingProps) {
+export function ScoreRing({ score, color, size = 36, baseScore }: ScoreRingProps) {
   const r = (size - 4) / 2;
   const circ = 2 * Math.PI * r;
-  const offset = circ * (1 - score / 100);
+  const rounded = Math.round(score);
+  const roundedBase = typeof baseScore === "number" ? Math.round(baseScore) : rounded;
+  const hasGain = roundedBase < rounded;
+
+  const offset = circ * (1 - rounded / 100);
+  const baseOffset = circ * (1 - roundedBase / 100);
+
   return (
     <div
       className="score-ring"
@@ -34,7 +49,26 @@ export function ScoreRing({ score, color, size = 36 }: ScoreRingProps) {
           stroke="var(--score-ring-track-stroke)"
           strokeWidth={2}
         />
-        {/* Progress ring */}
+        {/* Gain arc (partenza→ottimizzata): alone soft dello stesso colore fino
+            all'ottimizzato, disegnato sotto così il segmento di partenza lo
+            copre pieno e resta visibile solo il "salto". */}
+        {hasGain && (
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            fill="none"
+            stroke={color}
+            strokeOpacity={0.4}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeDasharray={circ}
+            strokeDashoffset={offset}
+            transform={`rotate(-90 ${size / 2} ${size / 2})`}
+            className="score-ring__progress score-ring__progress--gain"
+          />
+        )}
+        {/* Progress ring — pieno fino alla partenza (o all'unico punteggio). */}
         <circle
           cx={size / 2}
           cy={size / 2}
@@ -44,11 +78,11 @@ export function ScoreRing({ score, color, size = 36 }: ScoreRingProps) {
           strokeWidth={2}
           strokeLinecap="round"
           strokeDasharray={circ}
-          strokeDashoffset={offset}
+          strokeDashoffset={hasGain ? baseOffset : offset}
           transform={`rotate(-90 ${size / 2} ${size / 2})`}
           className="score-ring__progress"
         />
-        {/* Number */}
+        {/* Number — sempre l'ottimizzato (ciò che otterrai aprendo lo stile). */}
         <text
           x={size / 2}
           y={size / 2 + 0.5}
@@ -60,7 +94,7 @@ export function ScoreRing({ score, color, size = 36 }: ScoreRingProps) {
           fontFamily="var(--font-sans)"
           className="score-ring__text"
         >
-          {score}
+          {rounded}
         </text>
       </svg>
     </div>

--- a/src/app/features/recipe/style-detail-sheet.tsx
+++ b/src/app/features/recipe/style-detail-sheet.tsx
@@ -163,9 +163,11 @@ export function StyleDetailSheet({
           </motion.span>
         </IconButton>
 
-        {/* Close button */}
+        {/* Close button — stessa apparenza `bare` del fav: entrambi i controlli
+            in overlay condividono chrome e stati via `.style-detail-sheet__*`. */}
         <IconButton
           size="md"
+          variant="bare"
           onClick={onDismiss}
           className="style-detail-sheet__close-btn"
           aria-label={cms.ui.closeDetails}

--- a/src/app/pages/profile.tsx
+++ b/src/app/pages/profile.tsx
@@ -33,7 +33,7 @@ WheatOff,
 X,
 Zap,
 } from "lucide-react";
-import { AnimatePresence,motion } from "motion/react";
+import { AnimatePresence,motion, useReducedMotion } from "motion/react";
 import { useCallback,useEffect,useMemo,useState } from "react";
 import { createPortal } from "react-dom";
 import { Link, useNavigate } from "react-router";
@@ -1280,6 +1280,7 @@ export function ProfilePage() {
     return LOCALE_META.find((l) => l.id === cms.locale?.id) ?? LOCALE_META[0];
   }, [cms.locale?.id]);
   const [profileTab, setProfileTab] = useState<"setup" | "app" | "recipes">("setup");
+  const reduceMotion = useReducedMotion();
 
   /* FTU */
   if (showFtu) {
@@ -1356,7 +1357,14 @@ export function ProfilePage() {
                 onClick={() => setProfileTab(tab.id)}
                 className={active ? "profile-tabs__button profile-tabs__button--active" : "profile-tabs__button"}
               >
-                {tab.label}
+                {active && (
+                  <motion.span
+                    layoutId="profile-tab-indicator"
+                    className="profile-tabs__indicator"
+                    transition={reduceMotion ? { duration: 0 } : { type: "spring", stiffness: 380, damping: 32 }}
+                  />
+                )}
+                <span className="profile-tabs__label">{tab.label}</span>
               </button>
             );
           })}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1208,14 +1208,17 @@
 
   html {
     font-size: var(--font-size);
-    overflow-x: hidden;
+    /* `clip` non forza `overflow-y: auto` (a differenza di `hidden`), così html
+       e body non diventano scroll-container e `position: sticky` funziona
+       (pin VPL-149713). */
+    overflow-x: clip;
     max-width: 100%;
   }
 
   body {
     background-color: var(--background);
     color: var(--foreground);
-    overflow-x: hidden;
+    overflow-x: clip;
     max-width: 100%;
     font-family: var(--font-sans);
     font-kerning: normal;
@@ -2982,11 +2985,13 @@
   .profile-page__header-icon-glyph { color: var(--primary); }
   .profile-page__subtitle { font-family: var(--font-serif); font-style: italic; margin-top: var(--space-1); font-size: var(--font-size-xl); color: var(--text-muted); opacity: 0.65; }
   .profile-tabs { position: sticky; top: var(--space-3); z-index: 4; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-1); margin-bottom: var(--space-5); padding: var(--space-1); border-radius: var(--radius-2xl); background: color-mix(in srgb, var(--container-page) 86%, transparent); border: var(--border-width-thin) solid var(--container-border-subtle); box-shadow: var(--shadow-sm); backdrop-filter: blur(var(--blur-md)); -webkit-backdrop-filter: blur(var(--blur-md)); }
-  .profile-tabs__button { min-width: 0; padding-inline: var(--space-2); padding-block: var(--space-2); border-radius: var(--radius-xl); color: var(--text-muted); font-size: var(--font-size-sm); font-weight: var(--weight-semibold); line-height: var(--leading-tight); cursor: pointer; transition: transform 0.18s ease, background 0.18s ease, color 0.18s ease, box-shadow 0.18s ease; }
-  .profile-tabs__button:hover { color: var(--text-default); background: var(--surface-container-low); }
+  .profile-tabs__button { position: relative; min-width: 0; padding-inline: var(--space-2); padding-block: var(--space-2); border-radius: var(--radius-xl); color: var(--text-muted); font-size: var(--font-size-sm); font-weight: var(--weight-semibold); line-height: var(--leading-tight); cursor: pointer; transition: transform 0.18s ease, color 0.18s ease; }
+  .profile-tabs__button:hover:not(.profile-tabs__button--active) { color: var(--text-default); background: var(--surface-container-low); }
   .profile-tabs__button:focus-visible { outline: var(--space-0-5) solid color-mix(in srgb, var(--primary) 30%, transparent); outline-offset: var(--space-0-5); }
   .profile-tabs__button:active { transform: scale(0.97); }
-  .profile-tabs__button--active { color: var(--chip-text-active); background: var(--chip-bg-active); box-shadow: var(--shadow-sm); }
+  .profile-tabs__button--active { color: var(--chip-text-active); }
+  .profile-tabs__indicator { position: absolute; inset: 0; z-index: 0; border-radius: var(--radius-xl); background: var(--chip-bg-active); box-shadow: var(--shadow-sm); }
+  .profile-tabs__label { position: relative; z-index: 1; }
 
   /* ── Oven section (profile main) ── */
   .profile-oven-list { display: flex; flex-direction: column; gap: var(--gap-xs); }
@@ -5020,6 +5025,39 @@
   }
   .match-action-text--save-active {
     color: var(--primary);
+  }
+  .match-action-text:hover {
+    background: var(--container-bg);
+    border-color: color-mix(in srgb, var(--primary) 30%, var(--container-border-subtle));
+  }
+  /* Desktop (nota Matteo, pin VPL-452410 + VPL-419292): la card verdetto era
+     alta e vuota a destra, con le azioni poco visibili in coda. Su schermo largo
+     diventa a due colonne — verdetto a sinistra, cluster azioni impilato a
+     destra: riempie il vuoto e dà peso alle azioni. Sotto i 768px resta la
+     riga di azioni a piena larghezza. */
+  @media (min-width: 768px) {
+    .match-card {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--gap-lg);
+    }
+    .match-card__main {
+      flex: 1 1 0%;
+      min-width: 0;
+    }
+    .match-actions {
+      margin-top: var(--space-1);
+      flex: 0 0 auto;
+      width: auto;
+      min-width: max-content;
+      flex-direction: column;
+      align-items: stretch;
+      flex-wrap: nowrap;
+    }
+    .match-action-cta,
+    .match-action-text {
+      width: 100%;
+    }
   }
 
   /* ═══ ONDATA 3 — COMPONENT: ingredients-section (PREFIX: ingredients) ═══ */
@@ -9095,8 +9133,20 @@
 .style-detail-sheet__fav-btn {
   background: var(--surface-container);
   color: var(--text-default);
-  border: 1px solid var(--outline-variant);
+  border: var(--border-width-thin) solid var(--outline-variant);
   box-shadow: var(--shadow-sm);
+  transition: background 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+}
+.style-detail-sheet__close-btn:hover,
+.style-detail-sheet__fav-btn:hover {
+  background: var(--container-bg);
+  border-color: color-mix(in srgb, var(--primary) 26%, var(--outline-variant));
+  box-shadow: var(--shadow-md);
+}
+.style-detail-sheet__close-btn:focus-visible,
+.style-detail-sheet__fav-btn:focus-visible {
+  outline: var(--border-width-thin) solid color-mix(in srgb, var(--primary) 40%, transparent);
+  outline-offset: var(--space-0-5);
 }
 .style-detail-sheet__fav-btn--active {
   background: color-mix(in srgb, var(--primary) 14%, var(--surface-container));
@@ -9428,6 +9478,19 @@
 }
 @media (min-width: 640px) {
   .recommended-styles {
+    gap: var(--gap-xl);
+  }
+}
+
+/* Wrapper dei gruppi-tier: eredita la colonna spaziata così i tier restano
+   distanziati come quando erano figli diretti; porta il pulse di ricalcolo. */
+.recommended-styles__results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-lg);
+}
+@media (min-width: 640px) {
+  .recommended-styles__results {
     gap: var(--gap-xl);
   }
 }
@@ -10767,13 +10830,17 @@
   .app-shell-root {
     min-height: 100dvh;
     background: var(--container-page);
-    overflow-x: hidden;
+    /* `clip` invece di `hidden`: taglia il bleed orizzontale SENZA diventare
+       scroll-container (pin VPL-149713). `overflow-x: hidden` forzava
+       `overflow-y: auto`, così le section-tabs `position: sticky` si
+       ancoravano a questo antenato e non si agganciavano mai al viewport. */
+    overflow-x: clip;
     width: 100%;
     position: relative;
   }
 
   .app-shell-main {
-    overflow-x: hidden;
+    overflow-x: clip;
   }
 
   .app-shell-main--nav {

--- a/vulcan-debug-registry.json
+++ b/vulcan-debug-registry.json
@@ -388,8 +388,9 @@
     "comment": "sistemare questa nota, viene tagliata a sinistra per via del border radius",
     "priority": "low",
     "index": 8,
-    "updatedAt": 1783628907215,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783628940985",
@@ -466,8 +467,9 @@
     "comment": "non mi piace come abbiamo approfondito le quantità del prefermento... io avrei diviso la lista degli ingredienti",
     "priority": "high",
     "index": 9,
-    "updatedAt": 1783628975752,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629025952",
@@ -544,8 +546,9 @@
     "comment": "su questi picker ci dobbiamo decisamente lavorare... vedi quali sono le best practice e facciamo qualcosa di intuitivo e completo",
     "priority": "high",
     "index": 10,
-    "updatedAt": 1783629050051,
-    "deleted": false
+    "updatedAt": 1783757061747,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629073001",
@@ -701,8 +704,9 @@
     "comment": "quello che c'è sotto allo slider potrebbe animarsi",
     "priority": "medium",
     "index": 12,
-    "updatedAt": 1783629129038,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629149713",
@@ -779,8 +783,9 @@
     "comment": "perché non si aggancia?",
     "priority": "high",
     "index": 13,
-    "updatedAt": 1783629159208,
-    "deleted": false
+    "updatedAt": 1783757061747,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629199743",
@@ -1094,8 +1099,9 @@
     "comment": "manca tutto il discorso su resistenze (sopra sotto ecc), bruciatori, forma dei bruciatori ecc... Cerchiamo di farlo in maniera figa e che influenzi correttamente il motore",
     "priority": "high",
     "index": 17,
-    "updatedAt": 1783629344377,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629364973",
@@ -1172,8 +1178,9 @@
     "comment": "è corretta l'animazione e gli stati di questo elemento?",
     "priority": "high",
     "index": 18,
-    "updatedAt": 1783629377314,
-    "deleted": false
+    "updatedAt": 1783712430956,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629387247",
@@ -1215,8 +1222,9 @@
     "comment": "perché qui non è bianco? (e anche nel DS!)",
     "priority": "high",
     "index": 19,
-    "updatedAt": 1783629402189,
-    "deleted": false
+    "updatedAt": 1783717922054,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629428822",
@@ -1258,8 +1266,9 @@
     "comment": "Mettiamo iconcine (cuore, cuore spezzato ecc)",
     "priority": "high",
     "index": 20,
-    "updatedAt": 1783629445839,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629473814",
@@ -1301,8 +1310,9 @@
     "comment": "questo bordo è necessario da DS?",
     "priority": "high",
     "index": 21,
-    "updatedAt": 1783629484673,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629544157",
@@ -1396,8 +1406,9 @@
     "comment": "è corretto che questo button e quello Close abbiano status diversi?",
     "priority": "high",
     "index": 22,
-    "updatedAt": 1783629562372,
-    "deleted": false
+    "updatedAt": 1783712430956,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629589080",
@@ -1474,8 +1485,9 @@
     "comment": "preferisco gli elementi navbar in alto e non centrati",
     "priority": "high",
     "index": 23,
-    "updatedAt": 1783629606871,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629636021",
@@ -1552,8 +1564,9 @@
     "comment": "il cerca in material va qui?",
     "priority": "high",
     "index": 24,
-    "updatedAt": 1783629647048,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629662855",
@@ -1635,8 +1648,9 @@
     "comment": "sotto i risultati ora cambiano correttamente, ma senza animazioni di feedback",
     "priority": "high",
     "index": 25,
-    "updatedAt": 1783629696334,
-    "deleted": false
+    "updatedAt": 1783712430956,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629760265",
@@ -1720,8 +1734,9 @@
     "comment": "e la 1?",
     "priority": "high",
     "index": 26,
-    "updatedAt": 1783629767504,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629786081",
@@ -1821,8 +1836,9 @@
     "comment": "perché qui non indichiamo il tipo di farina ma solo la forza e nei filtri il contrario? Ragioniamoci su!",
     "priority": "high",
     "index": 27,
-    "updatedAt": 1783629806954,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629821071",
@@ -1922,8 +1938,9 @@
     "comment": "occhio che sull'hover la pillola viene tagliata in alto",
     "priority": "medium",
     "index": 28,
-    "updatedAt": 1783629835771,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629855048",
@@ -2023,8 +2040,9 @@
     "comment": "è possibile aggiungere \"Versione\"?",
     "priority": "high",
     "index": 29,
-    "updatedAt": 1783629869887,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629895403",
@@ -2124,8 +2142,9 @@
     "comment": "uhm non ci siamo come layout...",
     "priority": "high",
     "index": 30,
-    "updatedAt": 1783629902964,
-    "deleted": false
+    "updatedAt": 1783712430956,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629946995",
@@ -2225,8 +2244,9 @@
     "comment": "o li mettiamo per esteso, o mettiamo un tip",
     "priority": "high",
     "index": 31,
-    "updatedAt": 1783629966863,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783629985427",
@@ -2326,8 +2346,9 @@
     "comment": "non ha senso che la modale venga limitata in basso... dovrebbe essere TIPO pannello",
     "priority": "high",
     "index": 32,
-    "updatedAt": 1783630007067,
-    "deleted": false
+    "updatedAt": 1783712430956,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630059548",
@@ -2411,8 +2432,9 @@
     "comment": "dobbiamo trovare un compromesso fra questo storing e quello di Crea",
     "priority": "high",
     "index": 33,
-    "updatedAt": 1783630075115,
-    "deleted": false
+    "updatedAt": 1783717922054,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630099948",
@@ -2454,8 +2476,9 @@
     "comment": "questo sottotitolo dovrebbe essere legato alla selezione sottostante più che qui",
     "priority": "high",
     "index": 34,
-    "updatedAt": 1783630117348,
-    "deleted": false
+    "updatedAt": 1783757061747,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630161225",
@@ -2539,8 +2562,9 @@
     "comment": "togliere nota",
     "priority": "medium",
     "index": 35,
-    "updatedAt": 1783630165242,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630170488",
@@ -2624,8 +2648,9 @@
     "comment": "togliere sillabazione (dovrebbe essere usata solo come estrema ratio... qui andando a capo entrava)",
     "priority": "high",
     "index": 36,
-    "updatedAt": 1783630196952,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630219116",
@@ -2709,8 +2734,9 @@
     "comment": "che n e dici se qui mettiamo la versione animata del logo, che magari \"illumina\" col fuoco il glass della barra?",
     "priority": "high",
     "index": 37,
-    "updatedAt": 1783630246327,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630281602",
@@ -2794,8 +2820,9 @@
     "comment": "manca animazione chips. dovrebbe essere definita a livello di DS, di componente",
     "priority": "high",
     "index": 38,
-    "updatedAt": 1783630302069,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630314527",
@@ -2879,8 +2906,9 @@
     "comment": "back poco visibile. Dovrebbe rimanere persistente",
     "priority": "high",
     "index": 39,
-    "updatedAt": 1783630328385,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630341620",
@@ -2981,8 +3009,9 @@
     "comment": "icona cuore anche qui. più visibilità del match.",
     "priority": "high",
     "index": 40,
-    "updatedAt": 1783630361627,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630419292",
@@ -3083,8 +3112,9 @@
     "comment": "forse poco visibili?",
     "priority": "high",
     "index": 41,
-    "updatedAt": 1783630429881,
-    "deleted": false
+    "updatedAt": 1783757061747,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630452410",
@@ -3185,8 +3215,9 @@
     "comment": "non credi sia vuoto qui a destra?",
     "priority": "high",
     "index": 42,
-    "updatedAt": 1783630462281,
-    "deleted": false
+    "updatedAt": 1783757061747,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630479706",
@@ -3287,8 +3318,9 @@
     "comment": "e se mettessimo un glow? (diverso a seconda della situazione...)",
     "priority": "high",
     "index": 43,
-    "updatedAt": 1783630496498,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630503210",
@@ -3389,8 +3421,9 @@
     "comment": "button non ha stati/animazione",
     "priority": "high",
     "index": 44,
-    "updatedAt": 1783630520077,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630532189",
@@ -3491,8 +3524,9 @@
     "comment": "button SEMBRA avere elevation minore di elementi su cui passa sopra",
     "priority": "high",
     "index": 45,
-    "updatedAt": 1783630555539,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630564114",
@@ -3593,8 +3627,9 @@
     "comment": "per ora spegniamo questa feature, ovunque",
     "priority": "high",
     "index": 46,
-    "updatedAt": 1783630578147,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630635705",
@@ -3695,8 +3730,9 @@
     "comment": "che vuol dire \"questa versione assume\"? miglioriamo l'italiano",
     "priority": "high",
     "index": 47,
-    "updatedAt": 1783630652531,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783630688822",
@@ -3738,8 +3774,9 @@
     "comment": "più spazio sopra?",
     "priority": "medium",
     "index": 48,
-    "updatedAt": 1783630697055,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783663905765",
@@ -3840,8 +3877,9 @@
     "comment": "Ingredienti è addirittura più grande dell'h1!",
     "priority": "high",
     "index": 49,
-    "updatedAt": 1783663919123,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   },
   {
     "id": "anno-1783663941664",
@@ -4045,7 +4083,8 @@
     "comment": "invertirei il glow: la parte colorata a sinistra",
     "priority": "high",
     "index": 51,
-    "updatedAt": 1783666024925,
-    "deleted": false
+    "updatedAt": 1783711742697,
+    "deleted": false,
+    "resolved": true
   }
 ]


### PR DESCRIPTION
Chiude tutte le annotazioni di debug aperte sul recipe view e sui risultati (registry: 0 aperte).

## Modifiche
- **ScoreRing bi-tonale** — mostra *partenza → ottimizzata*: segmento pieno = compatibilità base, estensione soft-glow = salto da ottimizzazione; numero al centro = ottimizzato. Retro-compatibile (senza `baseScore` invariato).
- **match-card a due colonne** su desktop (≥768px) — verdetto a sinistra, cluster azioni impilato a destra: riempie il vuoto e dà peso alle azioni. Sotto i 768px resta la riga a piena larghezza. + hover sulle azioni testuali.
- **Fix sticky section-tabs** — `html`/`body`/`app-shell-*` da `overflow-x: hidden` a **`clip`** (`hidden` forzava `overflow-y: auto` → scroll-container) e tabs spostate **fuori** dal `motion.div` con `transform` che le catturava. Verificato: si agganciano a 64px.
- **procedure-hero** — stepper orari con frecce ↑↓ (±15 min) + tooltip sui pulsanti ±.
- **tab profilo** con indicatore animato (`layoutId`) + stati puliti.
- **style-detail-sheet** — fav e Close con stessa apparenza (`bare`) e hover/focus condivisi.
- **feedback pulse** sui risultati raccomandati al ricalcolo dei vincoli.

## Verifiche
- `npm run verify` verde (tsc, tokens, semantics, css-tokens, 84 test).
- Sticky confermato live (aggancio a 64px, misurato via DOM su due tab).
- Zero errori console su profilo/scopri/home/recipe.

## Note
- Le risoluzioni sono in `vulcan-debug-registry.json` (`resolved: true` + `updatedAt`), propagano a D1 last-write-wins al prossimo load.
- I log di sessione `.playwright-cli/*.log` non sono inclusi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)